### PR TITLE
Allow usage of an existing image pull secret

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -25,6 +25,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "image-pull-secrets" -}}
+{{- if .Values.global.imagePullSecret.enabled }}
+        - name: {{ template "image-pull-secret" . }}
+{{- end }}
+{{- with .Values.global.imagePullSecrets }}
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- if and (not .Values.global.imagePullSecret.enabled) (empty .Values.global.imagePullSecrets) -}}
+[]
+{{- end }}
+{{- end -}}
+
 {{- define "service-account" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/helm/templates/docker-registry-secret.yaml
+++ b/helm/templates/docker-registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.imagePullSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +8,6 @@ metadata:
 data:
   .dockercfg: "{{ .Values.global.imagePullSecret.dockercfg }}"
 type: kubernetes.io/dockercfg
+{{- end }}
 
 ---

--- a/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
+++ b/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
@@ -32,8 +32,7 @@ spec:
           path: /opt/nvidia-installer/cache/nvidia/{{ required "nvidiaDevicePlugin.nvidiaDriverVersion" .Values.nvidiaDevicePlugin.nvidiaDriverVersion }}
           type: Directory
         name: nvidia
-      imagePullSecrets:
-      - name: {{ template "image-pull-secret" . }}
+      imagePullSecrets: {{ template "image-pull-secrets" . }}
       containers:
       - name: nvidia-gpu-device-plugin
         image: {{ .Values.nvidiaDevicePlugin.devicePluginImage }}

--- a/helm/templates/ds-nvidia-installer.yaml
+++ b/helm/templates/ds-nvidia-installer.yaml
@@ -29,8 +29,7 @@ spec:
 {{ toYaml .Values.nvidiaInstaller.nodeAffinity | indent 10 }}
       {{- end}}
       hostPID: true
-      imagePullSecrets:
-      - name: {{ template "image-pull-secret" . }}
+      imagePullSecrets: {{ template "image-pull-secrets" . }}
       {{- if .Values.debug }}
       containers:
       {{- else }}

--- a/helm/todo-values.yaml
+++ b/helm/todo-values.yaml
@@ -1,10 +1,21 @@
 # This file contains the values that will usually need to be updated when changing versions of Garden Linux or NVIDIA driver
 
-# The Docker config will likely need to be set only once for a given deployment
+# The pull secret config will likely need to be set only once for a given deployment
 global:
+  # TODO: List of pre-existing secrets containing private registry credentials
+  # For example
+  # imagePullSecrets:
+  # - name: myRegistryKeySecretName
+  imagePullSecrets:
+  - name: myRegistryKeySecretName
+
+  # Configure a secret that should be created and then used for pulling images
   imagePullSecret:
+    # TODO: decide whether you want to create a new secret or use an existing one (using imagePullSecrets above)
+    enabled: false
     # TODO: change e30k to a base64-encoded Docker registry JSON authentication file
     dockercfg: "e30K"
+    annotations:
 
 nvidiaInstaller:
   # TODO: Set to the name of the image in the Docker registry

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,14 @@
 global:
+  # TODO: List of pre-existing secrets containing private registry credentials
+  # For example
+  # imagePullSecrets:
+  # - name: myRegistryKeySecretName
+  imagePullSecrets: []
+
+  # Configure a secret that should be created and then used for pulling images
   imagePullSecret:
+    # TODO: decide whether you want to create a new secret or use an existing one (using imagePullSecrets above)
+    enabled: false
     # TODO: change e30k to a base64-encoded Docker registry JSON authentication file
     dockercfg: "e30K"
     annotations:
@@ -42,8 +51,8 @@ nvidiaInstaller:
       cpu: 8
       memory: 1Gi
   environment:
-   - name: IGNORE_MISSING_MODULE_SYMVERS
-     value: "1"
+  - name: IGNORE_MISSING_MODULE_SYMVERS
+    value: "1"
 
 nvidiaDevicePlugin:
   # Image URI from https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/cmd/nvidia_gpu/device-plugin.yaml


### PR DESCRIPTION
**What this PR does / why we need it**: Allows the usage of an existing image pull secret instead of creating a new one

A new key `global.imagePullSecrets` can be used to specify a list of already existing imagePullSecrets to use.

**Special notes for your reviewer**:
The pattern I followed here seems to be somewhat common, it is applied like this in bitnami helm charts (for example here https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml#L18 but also in others https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L218 )
This implementation requires the full Kubernetes style format of ` - name : mySecretName` instead of a simplified form like ` - mySecretName` I believe it is better to do what Kubernetes does in order not to surprise users here.

The existing mechanism via `global.imagePullSecret` to create a secret is left intact but disabled by default.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Allows the usage of pre-existing image pull secrets instead of creating new ones by specifying `global.imagePullSecrets`
```

