### PR TITLE
give distinct labels to device-plugin and nvidia-installer when nameOverride is set

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: >
   A Helm chart to install NVIDIA GPU Support on Garden Linux-based Gardener clusters
 name: nvidia-installer
-version: 1.5.98
+version: 1.6.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -3,11 +3,13 @@
 Expand the name of the chart.
 */}}
 {{- define "nvidia-installer.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "nvidia-device-plugin.name" -}}
-{{- default "nvidia-device-plugin" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-device-plugin" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -3,13 +3,11 @@
 Expand the name of the chart.
 */}}
 {{- define "nvidia-installer.name" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "nvidia-device-plugin.name" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-device-plugin" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-nvidia-device-plugin" (default .Chart.Name .Values.nameOverride) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -17,9 +15,9 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 
-{{- define "garden-nvidia-installer.fullname" -}}
+{{- define "nvidia-installer.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "garden-%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "image-pull-secret" -}}

--- a/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
+++ b/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: {{ template "nvidia-device-plugin.name" . }}
+      name: {{ template "nvidia-device-plugin.fullname" . }}
   template:
     metadata:
       labels:
-        name: {{ template "nvidia-device-plugin.name" . }}
+        name: {{ template "nvidia-device-plugin.fullname" . }}
         k8s-app: {{ template "nvidia-device-plugin.name" . }}
     spec:
       {{- if .Values.nvidiaDevicePlugin.nodeAffinity }}

--- a/helm/templates/ds-nvidia-installer.yaml
+++ b/helm/templates/ds-nvidia-installer.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "garden-nvidia-installer.fullname" . }}
+  name: {{ template "nvidia-installer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "nvidia-installer.name" . }}
@@ -14,11 +14,11 @@ spec:
     type: OnDelete
   selector:
     matchLabels:
-      name: {{ template "nvidia-installer.name" . }}
+      name: {{ template "nvidia-installer.fullname" . }}
   template:
     metadata:
       labels:
-        name: {{ template "nvidia-installer.name" . }}
+        name: {{ template "nvidia-installer.fullname" . }}
         k8s-app: {{ template "nvidia-installer.name" . }}
     spec:
       serviceAccountName: {{ template "service-account" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,6 +13,7 @@ global:
     dockercfg: "e30K"
     annotations:
 
+# nameOverride: used-instead-of-chart-name
 debug: false
 
 imagePullSecrets:


### PR DESCRIPTION
**What this PR does / why we need it**: give distinct labels to decide plugin and nvidia-installer when nameOverride is set

**Special notes for your reviewer**:
These are used in the labels of the 2 daemonsets:

https://github.com/gardenlinux/gardenlinux-nvidia-installer/blob/12e1cf37fa62dc34f17841a53a6590750be45ff1/helm/templates/ds-k8s-nvidia-deviceplugin.yaml#L9-L16

https://github.com/gardenlinux/gardenlinux-nvidia-installer/blob/12e1cf37fa62dc34f17841a53a6590750be45ff1/helm/templates/ds-nvidia-installer.yaml#L15-L22

Having both daemonsets use the identical label selector would not be great which currently happens when setting nameOverride. 
Additionally by default the labels now include the release-name

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
distinct labels for installer and deviceplugin daemonset created pods
```
