### PR TITLE
share fields for nodeSelector, nodeAffinity and tolerations between daemonsets

### DIFF
--- a/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
+++ b/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
@@ -15,10 +15,10 @@ spec:
         name: {{ template "nvidia-device-plugin.name" . }}
         k8s-app: {{ template "nvidia-device-plugin.name" . }}
     spec:
-      {{- if .Values.nvidiaDevicePlugin.nodeAffinity }}
+      {{- if .Values.nodeAffinity }}
       affinity:
         nodeAffinity:
-{{  toYaml .Values.nvidiaDevicePlugin.nodeAffinity | indent 10 }}
+{{  toYaml .Values.nodeAffinity | indent 10 }}
       {{- end}}
       priorityClassName: system-node-critical
       volumes:
@@ -56,13 +56,13 @@ spec:
           mountPath: /dev
         - mountPath: /usr/local/nvidia
           name: nvidia
-{{- if .Values.nvidiaDevicePlugin.nodeSelector }}
+{{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nvidiaDevicePlugin.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
-{{- if .Values.nvidiaDevicePlugin.tolerations }}
+{{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.nvidiaDevicePlugin.tolerations | indent 6 }}
+{{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
   updateStrategy:
     type: RollingUpdate

--- a/helm/templates/ds-nvidia-installer.yaml
+++ b/helm/templates/ds-nvidia-installer.yaml
@@ -23,11 +23,11 @@ spec:
     spec:
       serviceAccountName: {{ template "service-account" . }}
       priorityClassName: system-node-critical
-      {{- if .Values.nvidiaInstaller.nodeAffinity }}
+      {{- if .Values.nodeAffinity }}
       affinity:
         nodeAffinity:
-{{ toYaml .Values.nvidiaInstaller.nodeAffinity | indent 10 }}
-      {{- end}}
+{{ toYaml .Values.nodeAffinity | indent 10 }}
+      {{- end }}
       hostPID: true
       imagePullSecrets: {{ template "image-pull-secrets" . }}
       {{- if .Values.debug }}
@@ -78,13 +78,13 @@ spec:
           mountPath: /opt/nvidia-installer/cache
         resources:
 {{ toYaml .Values.nvidiaInstaller.installerResources | indent 12 }}
-{{- if .Values.nvidiaInstaller.nodeSelector }}
+{{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nvidiaInstaller.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
-{{- if .Values.nvidiaInstaller.tolerations }}
+{{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.nvidiaInstaller.tolerations | indent 6 }}
+{{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
       volumes:
       - name: dev

--- a/helm/todo-values.yaml
+++ b/helm/todo-values.yaml
@@ -17,33 +17,23 @@ global:
     dockercfg: "e30K"
     annotations:
 
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: gpu
+        operator: Exists
+      - key: os-version
+        operator: In
+        # TODO: Edit <gardenlinux-version>
+        values: ["<gardenlinux-version>"]
+
 nvidiaInstaller:
   # TODO: Set to the name of the image in the Docker registry
   installerImage: nvidia-installer-<gardenlinux-version>-<driver-version>
   # TODO: Edit image tag
   installerTag: latest
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: gpu
-          operator: Exists
-        - key: os-version
-          operator: In
-          # TODO: Edit <gardenlinux-version>
-          values: ["<gardenlinux-version>"]
-          # Do not edit gardenlinuxVersion above - actual version is defined in mlf-gitops/services/nvidia-installer/values/<version>.yaml
 
 nvidiaDevicePlugin:
   # TODO: Edit <driver-version>
   nvidiaDriverVersion: <driver-version>
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: gpu
-          operator: Exists
-        - key: os-version
-          operator: In
-          # TODO: Edit <gardenlinux-version>
-          values: ["<gardenlinux-version>"]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,9 +13,29 @@ global:
     dockercfg: "e30K"
     annotations:
 
+# nameOverride: used-instead-of-chart-name
 debug: false
 
-imagePullSecrets:
+nodeSelector: {}
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: gpu
+        operator: Exists
+      - key: os-version
+        operator: In
+        # TODO: Edit <gardenlinux-version>
+        values: ["<gardenlinux-version>2"]
+tolerations:
+- key: "" # An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
+  operator: Exists
+  effect: NoSchedule
+- key: ""
+  operator: Exists
+  effect: NoExecute
+- key: CriticalAddonsOnly
+  operator: Exists
 
 nvidiaInstaller:
   # TODO: Edit <gardenlinux-version> and <driver-version> accordingly
@@ -24,25 +44,6 @@ nvidiaInstaller:
   installerTag: latest
   pauseImage: gcr.io/google_containers/pause-amd64:3.0
   hostDriverPath: /opt/drivers
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: gpu
-          operator: Exists
-        - key: os-version
-          operator: In
-          # TODO: Edit <gardenlinux-version>
-          values: ["<gardenlinux-version>"]
-  tolerations:
-  - key: "" # An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
-    operator: Exists
-    effect: NoSchedule
-  - key: ""
-    operator: Exists
-    effect: NoExecute
-  - key: CriticalAddonsOnly
-    operator: Exists
   installerResources:
     requests:
       cpu: 10m
@@ -60,26 +61,6 @@ nvidiaDevicePlugin:
   # TODO: Edit <driver-version>
   nvidiaDriverVersion: <driver-version>
   hostDevicePluginPath: /var/lib/kubelet/device-plugins
-  nodeSelector: {}
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: gpu
-          operator: Exists
-        - key: os-version
-          operator: In
-          # TODO: Edit <gardenlinux-version>
-          values: ["<gardenlinux-version>"]
-  tolerations:
-  - key: "" # An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.
-    operator: Exists
-    effect: NoSchedule
-  - key: ""
-    operator: Exists
-    effect: NoExecute
-  - key: CriticalAddonsOnly
-    operator: Exists
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**: In all common deployment scenarios we want to have the same nodeAffinity for both nvidia-installer as well ans nvidia-deviceplugin. This makes it so that the affinity is only specified once in the `values.yaml` file.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
move nodeSelector, nodeAffinity and tolerations to top level of values
```
