### PR TITLE
fix: do not rely on apt-cache metapackage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV LINUX_HEADERS=${LINUX_HEADERS}-$TARGET_ARCH
 COPY resources/extract_kernel_version.sh .
 COPY resources/compile.sh .
 
-RUN export KERNEL_VERSION=$(./extract_kernel_version.sh ${LINUX_HEADERS}) && ./compile.sh
+RUN export KERNEL_VERSION=$(./extract_kernel_version.sh) && ./compile.sh
 
 FROM debian:bookworm-slim as packager
 ARG TARGET_ARCH

--- a/resources/extract_kernel_version.sh
+++ b/resources/extract_kernel_version.sh
@@ -1,16 +1,12 @@
 #!/bin/bash
 
-# This helper script assumes you have the garden linux repository in your /etc/apt/sources.list configured
-#
-# Example: linux-headers-amd64 -> linux-headers-5.15-amd64 -> linux-headers-5.15.114-gardenlinux-amd64 
-# 
-# This script simply unfolds the package dependency until the real linux-header package is found. 
-# The real package contains the full kernel version (already in the name).
+# Assuming we are within a driver build container and want the latest kernel headers,
+# this line detects the kernel version by looking for the directory name format
+# inside /usr/lib/modules. Only the version number is extracted using grep and sorted numerically.
 
-kernel_pkg_name=$1
 
 get_depends(){
-    apt-cache depends "$1" | grep "Depends:" | cut -d':' -f2 | sed 's/^ //'
+    ls /usr/lib/modules | grep -Eo '[0-9]+\.[0-9]+.[0-9]+' | sort -V | tail -n 1
 }
 
 intermediate_meta_pkg=$(get_depends "$kernel_pkg_name")


### PR DESCRIPTION
Assuming we are within a driver build container and want the latest kernel headers, this new extract_kernel_version script detects the kernel version by looking for the directory name format inside /usr/lib/modules. Only the version number is extracted using grep and sorted numerically.
