### PR TITLE
fix: remove GH actions runner root dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,11 @@ RUN rm -rf /var/lib/apt/lists/* /usr/bin/dpkg /sbin/start-stop-daemon /usr/lib/x
          /usr/bin/chfn /usr/bin/gpasswd
 
 RUN mkdir -p /rootfs \
-        && cp -ar /bin /boot /etc /home /lib /lib64 /media /mnt /opt /out /root /run /sbin /srv /tmp /usr /var /rootfs
+        && cp -ar /bin /boot /etc /home /lib /lib64 /media /mnt /opt /out /root /run /sbin /srv /tmp /usr /var /rootfs \
+        && rm -rf /rootfs/opt/actions-runner
 
 FROM scratch
 
-COPY --from=packager /rootfs    /
+COPY --from=packager /rootfs /
 
 ENTRYPOINT ["/opt/nvidia-installer/load_install_gpu_driver.sh"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes build issues when using GH actions for building the project.
Without that fix, we are seeing issues such as follows:

```
info  kanikoExecute - error building image: error building stage: failed to execute command: copying dir: creating file: open /opt/actions-runner/_work/nvidia-domain/nvidia-domain/v1_360_0/piper: text file busy
```
