### PR TITLE
Allows skipping fabricmanager download and installation

### DIFF
--- a/resources/download_fabricmanager.sh
+++ b/resources/download_fabricmanager.sh
@@ -26,5 +26,9 @@ pushd /tmp/nvidia
 OUTDIR=/out/nvidia-fabricmanager/$DRIVER_VERSION
 FABRICMANAGER_ARCHIVE="fabricmanager-linux-$ARCH_TYPE-$DRIVER_VERSION-archive"
 FABRICMANAGER_URL="https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-$ARCH_TYPE/${FABRICMANAGER_ARCHIVE}.tar.xz"
-mkdir -p "$OUTDIR"
-wget --directory-prefix="${OUTDIR}" "${FABRICMANAGER_URL}"
+if [[ `wget  -S --spider FABRICMANAGER_URL  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+  mkdir -p "$OUTDIR"
+  wget --directory-prefix="${OUTDIR}" "${FABRICMANAGER_URL}"
+else
+  echo "No NVIDIA Fabric Manager for driver version $DRIVER_VERSION exists. Skipping download."
+fi

--- a/resources/install_fabricmanager.sh
+++ b/resources/install_fabricmanager.sh
@@ -18,19 +18,23 @@ if [[ "$GPU_NAME" =~ (A100|H100|H200|B100|B200) ]]; then
   OUTDIR=/out/nvidia-fabricmanager/$DRIVER_VERSION
   FABRICMANAGER_ARCHIVE="fabricmanager-linux-x86_64-$DRIVER_VERSION-archive"
 
-  # Extract archive
-  xz -d -v "${OUTDIR}/${FABRICMANAGER_ARCHIVE}.tar.xz"
-  tar xf "${OUTDIR}/${FABRICMANAGER_ARCHIVE}.tar" --directory="${OUTDIR}"
+  if [ -e ${OUTDIR}/${FABRICMANAGER_ARCHIVE}.tar.xz ]; then
+    # Extract archive
+    xz -d -v "${OUTDIR}/${FABRICMANAGER_ARCHIVE}.tar.xz"
+    tar xf "${OUTDIR}/${FABRICMANAGER_ARCHIVE}.tar" --directory="${OUTDIR}"
 
-  # Copy files to the right places
-  cp "${OUTDIR}"/"${FABRICMANAGER_ARCHIVE}"/bin/* /usr/local/bin
-  cp "${OUTDIR}"/"${FABRICMANAGER_ARCHIVE}"/lib/* /usr/local/lib
-  cp -ar "${OUTDIR}"/"${FABRICMANAGER_ARCHIVE}"/share/* /usr/share
-  sed 's/DAEMONIZE=1/DAEMONIZE=0/g' "${OUTDIR}/${FABRICMANAGER_ARCHIVE}/etc/fabricmanager.cfg" > /etc/fabricmanager.cfg
-  sed -i 's/LOG_FILE_NAME=.*$/LOG_FILE_NAME=/g' /etc/fabricmanager.cfg
+    # Copy files to the right places
+    cp "${OUTDIR}"/"${FABRICMANAGER_ARCHIVE}"/bin/* /usr/local/bin
+    cp "${OUTDIR}"/"${FABRICMANAGER_ARCHIVE}"/lib/* /usr/local/lib
+    cp -ar "${OUTDIR}"/"${FABRICMANAGER_ARCHIVE}"/share/* /usr/share
+    sed 's/DAEMONIZE=1/DAEMONIZE=0/g' "${OUTDIR}/${FABRICMANAGER_ARCHIVE}/etc/fabricmanager.cfg" > /etc/fabricmanager.cfg
+    sed -i 's/LOG_FILE_NAME=.*$/LOG_FILE_NAME=/g' /etc/fabricmanager.cfg
 
-  # Run Fabric Manager
-  nv-fabricmanager -c /etc/fabricmanager.cfg
+    # Run Fabric Manager
+    nv-fabricmanager -c /etc/fabricmanager.cfg
+  else
+    echo "No NVIDIA Fabric Manager archive was found. Skipping."
+  fi
 fi
 echo "Sleep infinity"
 sleep infinity


### PR DESCRIPTION
**What this PR does / why we need it**:

For some driver versions no Fabric Manager does exist, eg. 550.90.07 and for smaller GPUs the fabric manager is not needed at all. So we need the possibility to skip the fabricmanager download and installation.

This is what this PR does.  It skips the download if the file does not exist, and it also skips the installation if the archive does not exist.

**Which issue(s) this PR fixes**:
Fixes #26 

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

allow skipping download and installation of the fabricmanager if no compatibe version exists.

```
