### PR TITLE
feature: added the ability to provide a gpu_config.json file to the nvidia-device-plugin based on the charts values

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -46,3 +46,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default "nvidia-device-plugin" .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "nvidia-device-plugin.gpuConfig.fullname" -}}
+{{- $name := default "nvidia-device-plugin" .Values.nameOverride -}}
+{{- printf "%s-%s-gpu-config" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/templates/configmap-gpu-config.yaml
+++ b/helm/templates/configmap-gpu-config.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.nvidiaDevicePlugin.gpuConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nvidia-device-plugin.gpuConfig.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "nvidia-device-plugin.name" . }}
+data:
+  gpu_config.json: |
+{{ .Values.nvidiaDevicePlugin.gpuConfig.data | toJson | indent 4 }}
+{{- end }}

--- a/helm/templates/configmap-gpu-config.yaml
+++ b/helm/templates/configmap-gpu-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nvidiaDevicePlugin.gpuConfig.enabled }}
+{{- if .Values.nvidiaDevicePlugin.gpuConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,5 +8,5 @@ metadata:
     app: {{ template "nvidia-device-plugin.name" . }}
 data:
   gpu_config.json: |
-{{ .Values.nvidiaDevicePlugin.gpuConfig.data | toJson | indent 4 }}
+{{ .Values.nvidiaDevicePlugin.gpuConfig | toJson | indent 4 }}
 {{- end }}

--- a/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
+++ b/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
@@ -36,6 +36,11 @@ spec:
           path: /opt/nvidia-installer/cache/nvidia/{{ required "nvidiaDevicePlugin.nvidiaDriverVersion" .Values.nvidiaDevicePlugin.nvidiaDriverVersion }}
           type: Directory
         name: nvidia
+{{- if .Values.nvidiaDevicePlugin.gpuConfig.enabled }}
+      - configMap:
+          name: {{ template "nvidia-device-plugin.gpuConfig.fullname" . }}
+        name: gpu-config
+{{- end }}
       imagePullSecrets: {{ template "image-pull-secrets" . }}
       containers:
       - name: nvidia-gpu-device-plugin
@@ -60,6 +65,10 @@ spec:
           mountPath: /dev
         - mountPath: /usr/local/nvidia
           name: nvidia
+{{- if .Values.nvidiaDevicePlugin.gpuConfig.enabled }}
+        - mountPath: /etc/nvidia
+          name: gpu-config
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
+++ b/helm/templates/ds-k8s-nvidia-deviceplugin.yaml
@@ -36,7 +36,7 @@ spec:
           path: /opt/nvidia-installer/cache/nvidia/{{ required "nvidiaDevicePlugin.nvidiaDriverVersion" .Values.nvidiaDevicePlugin.nvidiaDriverVersion }}
           type: Directory
         name: nvidia
-{{- if .Values.nvidiaDevicePlugin.gpuConfig.enabled }}
+{{- if .Values.nvidiaDevicePlugin.gpuConfig }}
       - configMap:
           name: {{ template "nvidia-device-plugin.gpuConfig.fullname" . }}
         name: gpu-config
@@ -65,7 +65,7 @@ spec:
           mountPath: /dev
         - mountPath: /usr/local/nvidia
           name: nvidia
-{{- if .Values.nvidiaDevicePlugin.gpuConfig.enabled }}
+{{- if .Values.nvidiaDevicePlugin.gpuConfig }}
         - mountPath: /etc/nvidia
           name: gpu-config
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -70,12 +70,11 @@ nvidiaDevicePlugin:
       memory: 100Mi
     limits:
       memory: 100Mi
-  gpuConfig:
-    enabled: false
-    # Based on the go struct found here: https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/pkg/gpu/nvidia/manager.go#L70
-    data:
-      GPUPartitionSize: ""
-      GPUSharingConfig:
-        GPUSharingStrategy: ""
-        MaxSharedClientsPerGPU: 0
-      HealthCriticalXid: []
+# Uncomment the lines below to create and use `gpu_config.json`
+#  gpuConfig:
+#    # Based on the go struct found here: https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/pkg/gpu/nvidia/manager.go#L70
+#    GPUPartitionSize: ""
+#    GPUSharingConfig:
+#      GPUSharingStrategy: ""
+#      MaxSharedClientsPerGPU: 0
+#    HealthCriticalXid: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,3 +69,12 @@ nvidiaDevicePlugin:
       memory: 100Mi
     limits:
       memory: 100Mi
+  gpuConfig:
+    enabled: false
+    # Based on the go struct found here: https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/pkg/gpu/nvidia/manager.go#L70
+    data:
+      GPUPartitionSize: ""
+      GPUSharingConfig:
+        GPUSharingStrategy: ""
+        MaxSharedClientsPerGPU: 0
+      HealthCriticalXid: []


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables users to provide values for the `/etc/nvidia/gpu_config.json` file which is parsed [here](https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/cmd/nvidia_gpu/nvidia_gpu.go#L54-L71) and is used to populate [`GPUConfig`](https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/pkg/gpu/nvidia/manager.go#L70-L86) which controls gpu-sharing and Xid error handling for the gpus on each node.

**Which issue(s) this PR fixes**:
With the changes in this PR users can now enable shared gpu access based on `time-sharing` or `mps` which allows execution of more than one workload per gpu.

I assume that some more changes to Documentation and defaults may be required before merging.
I hope this is a good starting point for discussion surrounding the feature.
