### PR TITLE
GH Actions: Disable fail fast strategy

### DIFF
--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -25,6 +25,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
     env:


### PR DESCRIPTION
We need all jobs to run independently of issues of others
