### PR TITLE
GH Action: use cpu architecture dependent runner

### DIFF
--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -23,7 +23,7 @@ jobs:
 
   build:
     needs: generate-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}


### PR DESCRIPTION
No cross compilation, only native builds.

Each build target of the matrix gets an own runner of cpu arch of target driver arch
