### PR TITLE
Fix artifact path to reflect compile.sh script

### DIFF
--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -75,5 +75,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: driver-${{ matrix.os_name }}-${{ matrix.arch }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}
-          path: ${{ github.workspace }}/out/nvidia/${{ matrix.driver_version }}.tar.gz
+          path: ${{ github.workspace }}/out/nvidia/driver.tar.gz
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix artifact path in github runner to reflect compile.sh script

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
