### PR TITLE
complete-check required for github branch protection rule

### DIFF
--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -83,3 +83,15 @@ jobs:
           name: driver-${{ matrix.os_name }}-${{ matrix.arch }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}
           path: ${{ github.workspace }}/out/nvidia/driver.tar.gz
 
+  check-complete:
+    name: Pull Request Check
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    needs: build
+    steps:
+      - name: Ensure all matrix jobs passed
+        run: |
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "One or more build jobs failed."
+            exit 1
+          fi


### PR DESCRIPTION
**What this PR does / why we need it**:
`Require status checks to pass before merging` requires us to reference a job that must successfully run. 
Matrix jobs are dynamically created, and matrix as a whole can not be used as reference there.

**Which issue(s) this PR fixes**:
follow up for #58  #59 


**Special notes for your reviewer**:
otherwise we would need to manually add all matrix jobs manually in github ui everytime a new target appears (🙅🏻)
- build (1592, 1592.11, 550.127.08, amd64, cloud) 
- ...

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
