### PR TITLE
GH Action: build and publish container image

### DIFF
--- a/.ci/generate_matrix.py
+++ b/.ci/generate_matrix.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-import yaml, json
+import yaml
+import json
 
 with open("versions.yaml") as f:
     data = yaml.safe_load(f)
 
-matrix = []
+build_matrix = []
+manifest_set = set()
 for os in data["os_versions"]:
     for arch in os["cpu_arch"]:
         for flavour in os["kernel_flavour"]:
             for driver in os["nvidia_drivers"]:
-                matrix.append(
+                build_matrix.append(
                     {
                         "os_name": os["name"],
                         "os_version": os["version"],
@@ -18,5 +20,15 @@ for os in data["os_versions"]:
                         "kernel_flavour": flavour,
                     }
                 )
+                manifest_set.add((os["version"], flavour, driver))
 
-print(json.dumps({"include": matrix}))
+manifest_matrix = [
+    {"os_version": v, "kernel_flavour": k, "driver_version": d}
+    for v, k, d in sorted(manifest_set)
+]
+
+print(
+    json.dumps(
+        {"build": {"include": build_matrix}, "manifest": {"include": manifest_matrix}}
+    )
+)

--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          MATRIX=$(./.ci/generate_matrix.py)
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          MATRIX_JSON="$(python3 .ci/generate_matrix.py)"
+          echo "matrix=$(echo "$MATRIX_JSON" | jq -c '.build')" >> $GITHUB_OUTPUT
 
   build:
     needs: generate-matrix

--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -1,12 +1,7 @@
-name: Build Drivers
+name: Build Drivers (non-container artifacts)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
-
 
 jobs:
   generate-matrix:

--- a/.github/workflows/build_driver_container_image.yml
+++ b/.github/workflows/build_driver_container_image.yml
@@ -9,10 +9,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ toLower(github.repository) }}
 
 permissions:
   id-token: write
+  packages: write
 
 jobs:
   generate-matrix:
@@ -42,8 +42,17 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.build_matrix) }}
 
+    env:
+      TARGET_ARCH: ${{ matrix.arch }}
+      GL_VERSION: ${{ matrix.os_version }}
+      DRIVER_VERSION: ${{ matrix.driver_version }}
+      KERNEL_TYPE: ${{ matrix.kernel_flavour }}
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -54,12 +63,12 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          TAG="${{ matrix.arch }}-${{ matrix.os_version }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}"
+          TAG="$TARGET_ARCH-$GL_VERSION-$KERNEL_TYPE-$DRIVER_VERSION"
           docker build \
-            --build-arg GL_VERSION=${{ matrix.os_version }} \
-            --build-arg KERNEL_FLAVOUR=${{ matrix.kernel_flavour }} \
-            --build-arg DRIVER_VERSION=${{ matrix.driver_version }} \
-            --build-arg ARCH=${{ matrix.arch }} \
+            --build-arg GARDENLINUX_VERSION=$GL_VERSION \
+            --build-arg KERNEL_TYPE=$KERNEL_TYPE \
+            --build-arg DRIVER_VERSION=$DRIVER_VERSION \
+            --build-arg TARGET_ARCH=$TARGET_ARCH \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG} .
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}
 
@@ -76,6 +85,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> $GITHUB_ENV
 
       - name: Create and push multi-arch manifest
         run: |

--- a/.github/workflows/build_driver_container_image.yml
+++ b/.github/workflows/build_driver_container_image.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ toLower(github.repository) }}
 
 permissions:
   id-token: write
@@ -37,7 +37,7 @@ jobs:
 
   build:
     needs: generate-matrix
-    runs-on: ${{ build_matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.build_matrix) }}

--- a/.github/workflows/build_driver_container_image.yml
+++ b/.github/workflows/build_driver_container_image.yml
@@ -3,8 +3,9 @@ name: Build and Publish Docker Images (matrix)
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  pull_request:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build_driver_container_image.yml
+++ b/.github/workflows/build_driver_container_image.yml
@@ -37,7 +37,7 @@ jobs:
 
   build:
     needs: generate-matrix
-    runs-on: ${{ build_matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.build_matrix) }}

--- a/.github/workflows/build_driver_container_image.yml
+++ b/.github/workflows/build_driver_container_image.yml
@@ -1,0 +1,87 @@
+name: Build and Publish Docker Images (matrix)
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  id-token: write
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
+      manifest_matrix: ${{ steps.set-matrix.outputs.manifest_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PyYAML and jq
+        run: |
+          pip install pyyaml
+          sudo apt-get install -y jq
+
+      - name: Generate build and manifest matrices
+        id: set-matrix
+        run: |
+          MATRIX_JSON=$(python3 .ci/generate_matrix.py)
+          echo "build_matrix=$(echo "$MATRIX_JSON" | jq -c '.build')" >> $GITHUB_OUTPUT
+          echo "manifest_matrix=$(echo "$MATRIX_JSON" | jq -c '.manifest')" >> $GITHUB_OUTPUT
+
+  build:
+    needs: generate-matrix
+    runs-on: ${{ build_matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.build_matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          TAG="${{ matrix.arch }}-${{ matrix.os_version }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}"
+          docker build \
+            --build-arg GL_VERSION=${{ matrix.os_version }} \
+            --build-arg KERNEL_FLAVOUR=${{ matrix.kernel_flavour }} \
+            --build-arg DRIVER_VERSION=${{ matrix.driver_version }} \
+            --build-arg ARCH=${{ matrix.arch }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG} .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}
+
+  manifest:
+    needs: [build, generate-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.manifest_matrix) }}
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          MANIFEST_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os_version }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}"
+          AMD64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:amd64-${{ matrix.os_version }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}"
+          ARM64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:arm64-${{ matrix.os_version }}-${{ matrix.kernel_flavour }}-${{ matrix.driver_version }}"
+
+          docker manifest create $MANIFEST_TAG $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push $MANIFEST_TAG
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Builds container image and publishes to ghcr.io
- uses tags to identify various GL+nvidia+kernelflavour+arch combinations
 - multi arch oci manifest without arch in tag
   
