### PR TITLE
Use Driver Major version in image tag instead of complete version

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -77,6 +77,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Build and push Docker image
         run: |
           KERNEL_NAME="${{ steps.extract_kernel.outputs.kernel_name }}"

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -58,7 +58,6 @@ jobs:
             ./resources/extract_kernel_name.sh "$KERNEL_TYPE")
           echo "kernel_name=$KERNEL_NAME"
           echo "kernel_name=$KERNEL_NAME" >> $GITHUB_OUTPUT
-
       - name: Download driver artifact
         uses: actions/download-artifact@v4
         with:
@@ -82,7 +81,8 @@ jobs:
         run: |
           KERNEL_NAME="${{ steps.extract_kernel.outputs.kernel_name }}"
           IMAGE_NAME="driver"
-          TAG="$DRIVER_VERSION-$KERNEL_NAME-gardenlinux$GL_VERSION"
+          DRIVER_MAJOR_VERS="${DRIVER_VERSION%%.*}"
+          TAG="$DRIVER_MAJOR_VERS-$KERNEL_NAME-gardenlinux$GL_VERSION"
           docker build \
             --build-arg DRIVER_VERSION=$DRIVER_VERSION \
             --build-arg TARGET_ARCH=$TARGET_ARCH \

--- a/helm/gpu-operator-values.yaml
+++ b/helm/gpu-operator-values.yaml
@@ -6,7 +6,7 @@ toolkit:
 driver:
   imagePullPolicy: Always
   usePrecompiled: true
-  version: 570.172.08
+  version: 570
   repository: ghcr.io/gardenlinux/gardenlinux-nvidia-installer
 node-feature-discovery:
   worker:


### PR DESCRIPTION
**What this PR does / why we need it**:
Current Image tag uses Driver major version. This makes it difficult when there is an update in minor version. Hence use only major version in the image Tag
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
