### PR TITLE
Enhance driver install to support upgrades, Fabric Manager 580 naming, and nvidia-modprobe integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ ARG TARGET_ARCH
 ARG DRIVER_VERSION
 
 COPY --from=builder /out /out
+# This binary is not in the /out location as part of the nvidia-installer
+COPY --from=builder /usr/bin/nvidia-modprobe /usr/bin/nvidia-modprobe
 COPY resources/* /opt/nvidia-installer/
 
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/resources/download_fabricmanager.sh
+++ b/resources/download_fabricmanager.sh
@@ -23,5 +23,43 @@ pushd /tmp/nvidia
 # Download Fabric Manager tarball
 wget -O /tmp/keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb && dpkg -i /tmp/keyring.deb
 apt-get update
-apt-get install -V nvidia-fabricmanager-"$DRIVER_BRANCH"="$DRIVER_VERSION"-1
+#apt-get install -V nvidia-fabricmanager-"$DRIVER_BRANCH"="$DRIVER_VERSION"-1
 
+# As of Aug 27 2025 the 580 version of fabricmanager changed the nameing format
+# https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/
+# example names
+#
+#nvidia-fabricmanager-570_570.172.08-1_amd64.deb 7.2MB 2025-07-09 04:20
+#nvidia-fabricmanager-575_575.51.03-1_amd64.deb 7.2MB 2025-04-26 19:32
+#nvidia-fabricmanager-575_575.57.08-1_amd64.deb 7.2MB 2025-05-29 18:10
+#
+# However 580 has the following format
+# nvidia-fabricmanager_580.65.06-1_amd64.deb 7.3MB 2025-07-28 05:55
+#
+# So try and handle both cases.
+# =${VER} is pinning a package, I was not familiar with this format of referencing a package version.
+#
+PKG1="nvidia-fabricmanager-${DRIVER_BRANCH}"
+PKG2="nvidia-fabricmanager"
+VER="${DRIVER_VERSION}-1"
+
+has_exact_ver() { apt-cache madison "$1" 2>/dev/null | awk '{print $3}' | grep -Fx "$2" >/dev/null 2>&1; }
+
+PKG=""
+if has_exact_ver "$PKG1" "$VER"; then
+  PKG="$PKG1"
+elif has_exact_ver "$PKG2" "$VER"; then
+  PKG="$PKG2"
+fi
+
+if [ -z "$PKG" ]; then
+  echo "Not found via APT:"
+  echo "  ${PKG1} version ${VER}"
+  echo "  ${PKG2} version ${VER}"
+  echo "Available for ${PKG1}:"; apt-cache madison "$PKG1" | awk '{print "  " $3}' || true
+  echo "Available for ${PKG2}:"; apt-cache madison "$PKG2" | awk '{print "  " $3}' || true
+  exit 1
+fi
+
+echo "Installing via APT: ${PKG}=${VER}"
+apt-get install -y -V "${PKG}=${VER}"

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -1,38 +1,32 @@
 #!/bin/bash
-echo "Installing NVIDIA modules for driver version $DRIVER_VERSION"
-set -e
+set -euo pipefail
 
-error_out=$(depmod -b "$INSTALL_DIR/$DRIVER_NAME" 2>&1)
-# "grep -v ..." removes warnings that do not cause a problem for the gpu driver installation
+echo "Installing NVIDIA modules for driver version $DRIVER_VERSION"
+
+# Build dep maps relative to the alt root (your INSTALL_DIR/DRIVER_NAME)
+error_out=$(depmod -b "$INSTALL_DIR/$DRIVER_NAME" 2>&1 || true)
+# filter harmless depmod warnings
 echo "$error_out" | grep -v 'depmod: WARNING:' || true
 
+# Load modules into the host kernel from our alt rootfs
 modprobe -q -d "$INSTALL_DIR/$DRIVER_NAME" nvidia
 modprobe -q -d "$INSTALL_DIR/$DRIVER_NAME" nvidia-uvm
-if [ ! -e /dev/nvidia0 ] ; then
-    NVDEVS=$(lspci | grep -i NVIDIA)
-    N3D=$(echo "$NVDEVS" | grep -c "3D controller") || true
-    NVGA=$(echo "$NVDEVS" | grep -c "VGA compatible controller") || true
-    N=$((N3D + NVGA - 1)) || true
-    for i in $(seq 0 $N); do nsenter -t 1 -m -u -n -i mknod -m 666 /dev/nvidia"$i" c 195 "$i"; done
-fi
-if [ ! -e /dev/nvidiactl ] ; then
-    mknod -m 666 /dev/nvidiactl c 195 255
-fi
-if [ ! -e /dev/nvidia-uvm ] ; then
-    D=$(grep nvidia-uvm /proc/devices | cut -d " " -f 1)
-    mknod -m 666 /dev/nvidia-uvm c "$D" 0
-fi
 
-# For A100 GPUs we install additional device files to support Fabric Manager
-GPU_NAME=$("${NVIDIA_BIN}"/nvidia-smi -i 0 --query-gpu=name --format=csv,noheader)
-if [[ "$GPU_NAME" == *"A100"* ]]; then
-  "${NVIDIA_BIN}"/nvidia-modprobe --unified-memory --nvlink
-  "${NVIDIA_BIN}"/nvidia-modprobe --nvswitch -c 0
-  "${NVIDIA_BIN}"/nvidia-modprobe --nvswitch -c 1
-  "${NVIDIA_BIN}"/nvidia-modprobe --nvswitch -c 2
-  "${NVIDIA_BIN}"/nvidia-modprobe --nvswitch -c 3
-  "${NVIDIA_BIN}"/nvidia-modprobe --nvswitch -c 4
-  "${NVIDIA_BIN}"/nvidia-modprobe --nvswitch -c 5
+# Ensure device nodes exist on the host (idempotent, preferred over manual mknod)
+# -u: create /dev/nvidia-uvm
+# -c=0: create /dev/nvidia0..N and /dev/nvidiactl
+# nvidia-modprobe was created in the location /usr/bin location it is 
+# not installed part of NVIDIA_BIN by default unless we copy it there.
+nsenter -t 1 -m -u -n -i ${NVIDIA_BIN}/nvidia-modprobe -u -c=0 || true
+
+
+# A100 / NVSwitch extras — run in host namespaces as they affect host devices
+GPU_NAME=$("${NVIDIA_BIN}/nvidia-smi" -i 0 --query-gpu=name --format=csv,noheader || true)
+if [[ "${GPU_NAME:-}" == *"A100"* ]]; then
+  nsenter -t 1 -m -u -n -i ${NVIDIA_BIN}/nvidia-modprobe --unified-memory --nvlink || true
+  for c in 0 1 2 3 4 5; do
+    nsenter -t 1 -m -u -n -i ${NVIDIA_BIN}/nvidia-modprobe --nvswitch -c "$c" || true
+  done
 fi
 
 echo "NVIDIA driver installed OK"

--- a/resources/load_install_gpu_driver.sh
+++ b/resources/load_install_gpu_driver.sh
@@ -8,47 +8,75 @@ source "$BIN_DIR"/set_env_vars.sh
 LD_ROOT=${LD_ROOT:-/root}
 
 main() {
-    parse_parameters "${@}"
+    # Populate DRIVER_NAME, DRIVER_VERSION, NVIDIA_ROOT, etc.
+    parse_parameters "$@"
 
+    # Always run cleanup if your script provides it
     trap post_process EXIT
 
-    if ${DEBUG}; then
-      set -x
-    fi
+    # Safer shell defaults; optional tracing
+    set -euo pipefail
+    [ "${DEBUG:-false}" = "true" ] && set -x
 
-    check_status "${DRIVER_NAME}" "${DRIVER_VERSION}" && exit 0
-
-    tar xzf /out/nvidia/driver.tar.gz -C "/run/nvidia"
-
-    NVIDIA_BIN="${NVIDIA_ROOT}/bin"
-    install "$DRIVER_NAME" "$NVIDIA_BIN"
-
-    # So that nvidia-smi works for the NVIDIA GPU Operator startup probe
-    cp "$NVIDIA_BIN"/* /usr/bin
-
-    # For compatibility with the NVIDIA GPU Operator
-    cp "$NVIDIA_BIN"/* /usr/bin
-
-    if ! "${NVIDIA_BIN}/nvidia-smi"; then
-        echo "[ERROR] driver installation failed. Could not run nvidia-smi."
+    # ------------------------------------------------------------------------------
+    # 0) Guard: refuse to proceed if host NVIDIA modules are still loaded.
+    #    The GPU Operator's k8s-driver-manager should have evicted GPU users and
+    #    unloaded modules before we restage the driver. If modules are still loaded,
+    #    we bail out to avoid racing a live driver or mixing userlands.
+    # ------------------------------------------------------------------------------
+    if nsenter -t 1 -m -u -n -i lsmod | grep -qE '^(nvidia|nvidia_uvm|nvidia_modeset) '; then
+        echo "[ERROR] Host NVIDIA kernel modules are still loaded; refusing to restage."
+        echo "        Ensure driver-manager eviction/unload completed (or drain the node) and retry."
         exit 1
     fi
 
-}
+    # Stage new contents into a temporary directory
+    rm -rf /run/nvidia/.staging-driver || true
+    mkdir -p /run/nvidia/.staging-driver /run/nvidia/driver
 
-check_status() {
-    local DRIVER_NAME=$1
-    local DRIVER_VERSION=$2
-    # Check to see if /dev/nvidia0 exists already - this means that a previous driver version already exists,
-    #  in which case we don't want to overwrite with a conflicting new version
-    if [ -e /dev/nvidia0 ] && [ -e /dev/nvidiactl ] && [ -e /dev/nvidia-uvm ]; then
-      echo "[INFO] /dev/nvidia* files exist - driver version ${DRIVER_VERSION} already installed"
-      return 0
+    # extract INTO staging but drop the leading "driver/" path from the archive
+    tar xzf /out/nvidia/driver.tar.gz -C /run/nvidia/.staging-driver --strip-components=1
+
+    # Make /run/nvidia/driver an exact mirror of staging WITHOUT requiring rsync:
+    #  - First, remove existing contents of /run/nvidia/driver, including dotfiles.
+    #  - Then, copy everything from staging (preserving perms/links with -a).
+    #  Notes:
+    #    * We remove the contents, not the directory, to avoid breaking any watches.
+    #    * The glob trick handles hidden files/dirs (.[!.]* and ..?*).
+    #
+    # shellcheck disable=SC2115
+    rm -rf /run/nvidia/driver/* /run/nvidia/driver/.[!.]* /run/nvidia/driver/..?* 2>/dev/null || true
+    cp -a /run/nvidia/.staging-driver/. /run/nvidia/driver/
+    cp /usr/bin/nvidia-modprobe /run/nvidia/driver/bin 
+
+    # ------------------------------------------------------------------------------
+    # 1) Run install(): 
+    #    We also pass NVIDIA_BIN so probes can find tools easily inside this pod.
+    # ------------------------------------------------------------------------------
+    NVIDIA_BIN="${NVIDIA_ROOT}/bin"
+    install "$DRIVER_NAME" "$NVIDIA_BIN"
+
+    # ------------------------------------------------------------------------------
+    # 4) Make the CLI tools available INSIDE THIS POD (not the host) for probes.
+    #    We intentionally avoid host /usr/bin to prevent conflicts with the OS.
+    # ------------------------------------------------------------------------------
+    cp "${NVIDIA_BIN}"/* /usr/bin
+
+    # ------------------------------------------------------------------------------
+    # 5) Final verification from the pod. This exercises host devices (/dev/nvidia*)
+    #    through the container and ensures userland is in place for probes.
+    # ------------------------------------------------------------------------------
+    if ! /usr/bin/nvidia-smi >/dev/null 2>&1; then
+        echo "[ERROR] driver installation failed: nvidia-smi did not run successfully."
+        # Best-effort diagnostics
+        ls -l /dev/nvidia* 2>/dev/null || true
+        nsenter -t 1 -m -u -n -i lsmod | grep -E '^(nvidia|nvidia_uvm|nvidia_modeset) ' || true
+        exit 1
     fi
 
-    echo "$DRIVER_NAME $DRIVER_VERSION is out of date" 1>&2
-    return 1;
+    echo "[INFO] NVIDIA driver install/refresh OK for ${DRIVER_NAME}:${DRIVER_VERSION}"
 }
+
 
 install() {
     local DRIVER_NAME=$1


### PR DESCRIPTION
**What this PR does / why we need it**:

- **Supports driver upgrades/reinstalls safely** by staging the unpacked driver into `/.staging-driver` and then mirroring into `/run/nvidia/driver`, avoiding partial/in-place updates.
- **Handles Fabric Manager 580+ naming change** by probing both `nvidia-fabricmanager-${DRIVER_BRANCH}` and `nvidia-fabricmanager` with exact version pinning.
- **Integrates `nvidia-modprobe`** (copied into the image) and uses it via `nsenter` to create device nodes and NVSwitch devices instead of manual `mknod`, making setup idempotent and less error-prone.
- Hardens scripts with `set -euo pipefail`, better diagnostics, and a guard that refuses restaging if host NVIDIA modules are still loaded.

**Which issue(s) this PR fixes**:  
Fixes #

**Special notes for your reviewer**:

- Files touched:
  - `Dockerfile` – copy `/usr/bin/nvidia-modprobe` from builder stage.
  - `resources/download_fabricmanager.sh` – detect & install Fabric Manager across legacy (`nvidia-fabricmanager-<branch>`) and 580+ (`nvidia-fabricmanager`) package names with exact `=${VERSION}-1` pinning; prints available versions on failure.
  - `resources/install.sh` – use `nvidia-modprobe` via `nsenter` to create `/dev/nvidia*`, `nvidia-uvm`, and NVSwitch nodes (A100), instead of manual `mknod`; keep `depmod` warnings non-fatal; stronger error handling.
  - `resources/load_install_gpu_driver.sh` – staging flow, atomic mirror into `/run/nvidia/driver`, explicit cleanup of hidden files, verification via `nvidia-smi`, and a guard to avoid running while host modules are still loaded.
- Assumptions:
  - The builder stage provides `/usr/bin/nvidia-modprobe`. (We explicitly copy it into the final image.)
  - Driver eviction/unload is handled by the operator’s driver manager before we restage (we added a check; if modules are loaded, we bail with guidance).
- Backward compatibility:
  - Fabric Manager logic keeps working for 570/575 (old naming) and 580+ (new naming).
  - Using `nvidia-modprobe` is a drop-in improvement for device node management.
- Risks:
  - If an environment does not include `nvidia-modprobe` in the builder stage, the image build will fail (intended; we need it at runtime).
  - The added “modules-loaded” guard will cause early exit if the node hasn’t been properly drained/evicted.

**Release note**:
```feature operator
Improve driver install robustness:
- Support Fabric Manager 580+ package naming
- Safe restage/upgrade flow via staging dir
- Use `nvidia-modprobe` (with nsenter) for device creation and NVSwitch setup