### PR TITLE
Build, push & use images with Garden Linux version set to 0

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -83,13 +83,16 @@ jobs:
           KERNEL_NAME="${{ steps.extract_kernel.outputs.kernel_name }}"
           IMAGE_NAME="driver"
           DRIVER_MAJOR_VERS="${DRIVER_VERSION%%.*}"
-          TAG="$DRIVER_MAJOR_VERS-$KERNEL_NAME-gardenlinux$GL_VERSION"
+          TAG1="$DRIVER_MAJOR_VERS-$KERNEL_NAME-gardenlinux$GL_VERSION"
+          TAG2="$DRIVER_MAJOR_VERS-$KERNEL_NAME-gardenlinux0"
           docker build \
             --build-arg DRIVER_VERSION=$DRIVER_VERSION \
             --build-arg TARGET_ARCH=$TARGET_ARCH \
-            -t ${{ env.REGISTRY }}/${{ env.FOLDER_NAME }}/${IMAGE_NAME}:${TAG} \
+            -t ${{ env.REGISTRY }}/${{ env.FOLDER_NAME }}/${IMAGE_NAME}:${TAG1} \
+            -t ${{ env.REGISTRY }}/${{ env.FOLDER_NAME }}/${IMAGE_NAME}:${TAG2} \
             -f Dockerfile.precompiled .
-          docker push ${{ env.REGISTRY }}/${{ env.FOLDER_NAME }}/${IMAGE_NAME}:${TAG}
+          docker push ${{ env.REGISTRY }}/${{ env.FOLDER_NAME }}/${IMAGE_NAME}:${TAG1}
+          docker push ${{ env.REGISTRY }}/${{ env.FOLDER_NAME }}/${IMAGE_NAME}:${TAG2}
 
   manifest:
     needs: [build, generate-matrix]

--- a/helm/gpu-operator-values.yaml
+++ b/helm/gpu-operator-values.yaml
@@ -15,7 +15,7 @@ node-feature-discovery:
         custom:
           - name: "gardenlinux-version"
             labelsTemplate: |
-              {{ range .system.osrelease }}feature.node.kubernetes.io/system-os_release.VERSION_ID={{ .Value }}
+              {{ range .system.osrelease }}feature.node.kubernetes.io/system-os_release.VERSION_ID=0
               {{ end }}
             matchFeatures:
               - feature: system.osrelease


### PR DESCRIPTION
This helps mitigate https://github.com/NVIDIA/gpu-operator/issues/1622

By always setting the Garden Linux version to 0 we avoid the version confusion introduced by the bug. As a result the DaemonSets & related images are differentiated only by the kernel version (which already includes "gardenlinux" in the name).