### PR TITLE
fix: also check nvidia-fabricmanager-$DRIVER_MAJOR

### DIFF
--- a/resources/download_fabricmanager.sh
+++ b/resources/download_fabricmanager.sh
@@ -100,6 +100,7 @@ apt-get update
 #
 PKG1="nvidia-fabricmanager-${DRIVER_BRANCH}"
 PKG2="nvidia-fabricmanager"
+PKG3="nvidia-fabricmanager-$(echo "${DRIVER_BRANCH}" | cut -d. -f1)"
 VER="${DRIVER_VERSION}-1"
 
 has_exact_ver() { apt-cache madison "$1" 2>/dev/null | awk '{print $3}' | grep -Fx "$2" >/dev/null 2>&1; }
@@ -109,14 +110,18 @@ if has_exact_ver "$PKG1" "$VER"; then
   PKG="$PKG1"
 elif has_exact_ver "$PKG2" "$VER"; then
   PKG="$PKG2"
+elif has_exact_ver "$PKG3" "$VER"; then
+  PKG="$PKG3"
 fi
 
 if [ -z "$PKG" ]; then
   echo "Not found via APT:"
   echo "  ${PKG1} version ${VER}"
   echo "  ${PKG2} version ${VER}"
+  echo "  ${PKG3} version ${VER}"
   echo "Available for ${PKG1}:"; apt-cache madison "$PKG1" | awk '{print "  " $3}' || true
   echo "Available for ${PKG2}:"; apt-cache madison "$PKG2" | awk '{print "  " $3}' || true
+  echo "Available for ${PKG3}:"; apt-cache madison "$PKG3" | awk '{print "  " $3}' || true
   exit 1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
nvidia-fabricmanager pkg in https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/Packages changed naming again.

Currently it is named `nvidia-fabricmanager-570` and version of that package is `Version: 570.172.08-1`.

I doubt that this solution is sustainable when `nvidia-fabricmanager-570`  packages moves on to new minor or patch level, but we try to built for `Version: 570.172.08-1`. 


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
