### PR TITLE
Use GL image instead of bookworm:slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:bookworm-slim AS packager
+# syntax=docker/dockerfile:1.4
+ARG GL_VERSION
+
+FROM ghcr.io/gardenlinux/gardenlinux:${GL_VERSION} AS packager
 ARG TARGET_ARCH
 ARG DRIVER_VERSION
 ARG KERNEL_NAME

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ build-driver: extract-kernel-name
 build-image: extract-kernel-name
 	$(eval TAG1 := "$(DRIVER_MAJOR_VERS)-$(KERNEL_NAME)-gardenlinux$(GL_VERSION)")
 	$(eval TAG2 := "$(DRIVER_MAJOR_VERS)-$(KERNEL_NAME)-gardenlinux0")
-	@docker build \
+	@DOCKER_BUILDKIT=1 docker build \
+	   --build-arg GL_VERSION=$(GL_VERSION) \
            --build-arg DRIVER_VERSION=$(DRIVER_VERSION) \
            --build-arg TARGET_ARCH=$(TARGET_ARCH) \
            --build-arg KERNEL_NAME=$(KERNEL_NAME) \


### PR DESCRIPTION
**What this PR does / why we need it**:
It replaces the bookworm base image with Garden Linux Image to make maintenance easier
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardenlinux/gardenlinux-nvidia-installer/issues/90
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
