### PR TITLE
When doing a release or building from main, build & publish artifacts to the current release

### DIFF
--- a/.github/workflows/build_driver.yml
+++ b/.github/workflows/build_driver.yml
@@ -57,10 +57,16 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # On a tag build github.ref_name is the tag (e.g. "v1.2.3").
-          # On a branch build it is the branch name (e.g. "main").
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
+          # On main, use the latest release tag matching v[0-9].[0-9].[0-9].
+          # On a tag build github.ref_name is the tag itself (e.g. "v1.2.3").
+          # On any other branch it falls back to the branch name.
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            RELEASE_TAG=$(gh release list --repo "${{ github.repository }}" --json tagName \
+              --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first | .tagName')
+          else
+            RELEASE_TAG="${{ github.ref_name }}"
+          fi
           # Create the release if it does not yet exist; ignore error if it already does.
           gh release create "${RELEASE_TAG}" \
             --title "${RELEASE_TAG}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 on:
   workflow_dispatch:
+  release:
+    types:
+      - published
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Previously, builds triggered from the `main` branch would publish driver tarballs to a GitHub Release named `"main"` rather than attaching them to an actual versioned release. This meant tarballs built from `main` were never associated with the latest release tag.

## Changes

- **`build_driver.yml`**: In the "Publish tarball to GitHub Release" step, when running on `main`, `RELEASE_TAG` is now resolved dynamically by querying `gh release list` for the latest tag matching `v[0-9]+\.[0-9]+\.[0-9]+` (e.g. `v1.0.4`). Tag builds and other branches continue to use `github.ref_name` as before.
- **`release.yml`**: Added `release: published` as a trigger so the full build pipeline also runs automatically when a new GitHub Release is published.

## Behaviour

| Context | `RELEASE_TAG` used |
|---|---|
| Push to `main` | Latest `vX.Y.Z` release tag |
| Tag build (e.g. `v1.2.3`) | `v1.2.3` |
| Feature branch | Branch name (unchanged) |