### PR TITLE
Fix ancient version filtering to operate per major GL version

### DIFF
--- a/.ci/update_versions.py
+++ b/.ci/update_versions.py
@@ -59,13 +59,20 @@ def get_latest_gardenlinux_tags(data):
     tags = [tag['name'] for tag in response.json()]
     new_os_versions = [tag for tag in tags if re.fullmatch(r'\d+\.\d+(\.\d+)?', tag)]
 
-    # Any versions removed from the end of the old versions file, make sure they are removed from the new versions file
+    # Group new_os_versions by major version (first numeric component)
+    major_versions = {}
+    for tag in new_os_versions:
+        major = tag.split('.')[0]
+        major_versions.setdefault(major, []).append(tag)
+
+    # For each major version group, remove versions older than the oldest one tracked in data
     ancient_versions = []
-    for i in reversed(new_os_versions):
-        if i not in data['os_versions']:
-            ancient_versions.append(i)
-        else: # Stop when we get a match, so we avoid also removing the new versions at the top
-            break
+    for major, versions in major_versions.items():
+        for i in reversed(versions):
+            if i not in data['os_versions']:
+                ancient_versions.append(i)
+            else:  # Stop when we get a match, so we avoid also removing new versions at the top
+                break
 
     filtered_os_versions = [x for x in new_os_versions if x not in ancient_versions]
 

--- a/.ci/update_versions.py
+++ b/.ci/update_versions.py
@@ -59,7 +59,7 @@ def get_latest_gardenlinux_tags(data):
     tags = [tag['name'] for tag in response.json()]
     new_os_versions = [tag for tag in tags if re.fullmatch(r'\d+\.\d+(\.\d+)?', tag)]
 
-    # Group new_os_versions by major version (first numeric component)
+    # Any older versions of Garden Linux removed from the old versions file should not appear in the new versions file
     major_versions = {}
     for tag in new_os_versions:
         major = tag.split('.')[0]


### PR DESCRIPTION
Previously, the ancient-version pruning stopped at the first global match across all versions, so
older minor releases of one major branch (e.g. 1877) could be incorrectly retained if a newer
major branch (e.g. 1592) matched first. Group versions by major number and apply the cutoff
independently within each group.


