### PR TITLE
feat: support kernel module params via /drivers conf files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,13 @@ Image tags (three per build):
 - `{DRIVER_MAJOR}-{KERNEL_VERSION}-gardenlinux0`
 - `{DRIVER_VERSION}-{KERNEL_VERSION}-gardenlinux0`
 
+## Quirks & Gotchas
+
+- **GL_VERSION format**: Use two-part version (`1877.17`, `2150.3`), NOT three-part (`1877.17.0`). The kmodbuild image tag is `kmodbuild:amd64-{GL_VERSION}` and will fail with `manifest unknown` if you use a three-part version.
+- **`make build` vs `make build-image`**: If no pre-compiled tarball exists in `out/nvidia/` for the target GL version, run `make build` (not `make build-image`) to compile + package. `make build-image` alone will fail if the tarball is missing.
+- **Mixed-kernel clusters**: During GL version upgrades, different nodes may run different kernels. The GPU Operator creates one DaemonSet per kernel version — both the old and new kernel images may need to be pushed.
+- **B200 node recovery**: After a cluster node replacement, the B200 node may stay `NotReady` for 10–20+ minutes before NFD labels it and the GPU Operator creates a driver DaemonSet for it.
+
 # Coding guidelines
 
 ## 1. Think Before Coding

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,22 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends -y \
 # on Blackwell (B200) hosts to detect NVL5+ NVLink topology. It is not present in
 # the Garden Linux 2150 main repo, so we pull it from Debian unstable, pinned to
 # only the ibstat package set (Garden Linux is Debian-sid based, so ABI matches).
-RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/debian-unstable.list \
-    && printf 'Package: *\nPin: release a=unstable\nPin-Priority: -1\n\nPackage: infiniband-diags libibnetdisc5* libibmad5* libibumad3*\nPin: release a=unstable\nPin-Priority: 500\n' > /etc/apt/preferences.d/debian-unstable \
-    && apt-get -o Acquire::AllowInsecureRepositories=true update -qq \
-    && apt-get install -qq --no-install-recommends -y --allow-unauthenticated infiniband-diags \
+# debian-archive-keyring is installed first so apt can verify the sid Release
+# signature. signed-by= scopes the trusted key to this source line only.
+# All four packages (incl. transitive deps) are pinned to exact versions so
+# rebuilds are deterministic: infiniband-diags=63.0-1 pulls
+# libibnetdisc5t64=63.0-1, libibmad5=63.0-1, libibumad3=63.0-1.
+RUN apt-get install -qq --no-install-recommends -y debian-archive-keyring \
+    && echo "deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian unstable main" \
+        > /etc/apt/sources.list.d/debian-unstable.list \
+    && printf 'Package: *\nPin: release a=unstable\nPin-Priority: -1\n\nPackage: infiniband-diags libibnetdisc5t64 libibmad5 libibumad3\nPin: release a=unstable\nPin-Priority: 500\n' \
+        > /etc/apt/preferences.d/debian-unstable \
+    && apt-get update -qq \
+    && apt-get install -qq --no-install-recommends -y \
+        infiniband-diags=63.0-1 \
+        libibnetdisc5t64=63.0-1 \
+        libibmad5=63.0-1 \
+        libibumad3=63.0-1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /opt/nvidia-installer/download_fabricmanager.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,16 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
+# infiniband-diags (provides ibstat) is required by nvidia-fabricmanager-start.sh
+# on Blackwell (B200) hosts to detect NVL5+ NVLink topology. It is not present in
+# the Garden Linux 2150 main repo, so we pull it from Debian unstable, pinned to
+# only the ibstat package set (Garden Linux is Debian-sid based, so ABI matches).
+RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/debian-unstable.list \
+    && printf 'Package: *\nPin: release a=unstable\nPin-Priority: -1\n\nPackage: infiniband-diags libibnetdisc5* libibmad5* libibumad3*\nPin: release a=unstable\nPin-Priority: 500\n' > /etc/apt/preferences.d/debian-unstable \
+    && apt-get -o Acquire::AllowInsecureRepositories=true update -qq \
+    && apt-get install -qq --no-install-recommends -y --allow-unauthenticated infiniband-diags \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN /opt/nvidia-installer/download_fabricmanager.sh
 
 # Remove several things that are not needed, some of which raise Black Duck scan vulnerabilities

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -39,7 +39,7 @@ echo "$error_out" | grep -v 'depmod: WARNING:'
 # (existing files may have been configured by GPU Operator - see driver.kernelModuleConfig Helm value)
 # This disables High Memory Mode (hmm) which fixes an issue with B200 GPUs.
 mkdir -p /drivers
-cp nvidia-uvm.conf --no-clobber {} /drivers
+cp /opt/nvidia-installer/nvidia-uvm.conf --no-clobber {} /drivers
 
 _get_module_params
 echo -n "/run/nvidia/driver/lib/firmware" > /sys/module/firmware_class/parameters/path

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -38,6 +38,7 @@ echo "$error_out" | grep -v 'depmod: WARNING:'
 # Copy local nvidia-uvm.conf files to /drivers, but don't overwrite.
 # (existing files may have been configured by GPU Operator - see driver.kernelModuleConfig Helm value)
 # This disables High Memory Mode (hmm) which fixes an issue with B200 GPUs.
+mkdir -p /drivers
 cp nvidia-uvm.conf --no-clobber {} /drivers
 
 _get_module_params

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -39,9 +39,10 @@ echo "$error_out" | grep -v 'depmod: WARNING:'
 # (existing files may have been configured by GPU Operator - see driver.kernelModuleConfig Helm value)
 # This disables High Memory Mode (hmm) which fixes an issue with B200 GPUs.
 mkdir -p /drivers
-cp /opt/nvidia-installer/nvidia-uvm.conf --no-clobber {} /drivers
+cp --no-clobber /opt/nvidia-installer/nvidia-uvm.conf /drivers
 
 _get_module_params
+
 echo -n "/run/nvidia/driver/lib/firmware" > /sys/module/firmware_class/parameters/path
 modprobe -d "$INSTALL_DIR/$DRIVER_NAME" nvidia "${NVIDIA_MODULE_PARAMS[@]}"; rc=$?
 [ $rc -ne 0 ] && { echo "[ERROR] modprobe nvidia failed: $rc"; exit 1; }

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
 #set -euo pipefail
 
+NVIDIA_MODULE_PARAMS=()
+NVIDIA_UVM_MODULE_PARAMS=()
+
+# Read optional kernel module parameters from conf files mounted at /drivers/.
+# Each line in the file is one parameter token, e.g. "NVreg_DeviceFileMode=0666".
+# Multiple parameters: one per line.
+_get_module_params() {
+    local base_path="/drivers"
+    if [ -f "${base_path}/nvidia.conf" ]; then
+        while read -r param || [ -n "$param" ]; do
+            [[ -z "$param" || "$param" == \#* ]] && continue
+            NVIDIA_MODULE_PARAMS+=("$param")
+        done <"${base_path}/nvidia.conf"
+        echo "Module parameters provided for nvidia: ${NVIDIA_MODULE_PARAMS[*]}"
+    fi
+    if [ -f "${base_path}/nvidia-uvm.conf" ]; then
+        while read -r param || [ -n "$param" ]; do
+            [[ -z "$param" || "$param" == \#* ]] && continue
+            NVIDIA_UVM_MODULE_PARAMS+=("$param")
+        done <"${base_path}/nvidia-uvm.conf"
+        echo "Module parameters provided for nvidia-uvm: ${NVIDIA_UVM_MODULE_PARAMS[*]}"
+    fi
+}
+
 echo "Installing NVIDIA modules for driver version $DRIVER_VERSION"
 echo "INSTALL_DIR: $INSTALL_DIR"
 echo "DRIVER_NAME: $DRIVER_NAME"
@@ -9,11 +33,19 @@ echo "NVIDIA_BIN: $NVIDIA_BIN"
 # Build dep maps relative to the alt root (your INSTALL_DIR/DRIVER_NAME)
 error_out=$(depmod -b "$INSTALL_DIR/$DRIVER_NAME" 2>&1 )
 # filter harmless depmod warnings
-echo "$error_out" | grep -v 'depmod: WARNING:' 
+echo "$error_out" | grep -v 'depmod: WARNING:'
 
+# Copy local nvidia-uvm.conf files to /drivers, but don't overwrite.
+# (existing files may have been configured by GPU Operator - see driver.kernelModuleConfig Helm value)
+# This disables High Memory Mode (hmm) which fixes an issue with B200 GPUs.
+cp nvidia-uvm.conf --no-clobber {} /drivers
+
+_get_module_params
 echo -n "/run/nvidia/driver/lib/firmware" > /sys/module/firmware_class/parameters/path
-modprobe -q -d "$INSTALL_DIR/$DRIVER_NAME" nvidia
-modprobe -q -d "$INSTALL_DIR/$DRIVER_NAME" nvidia-uvm
+modprobe -d "$INSTALL_DIR/$DRIVER_NAME" nvidia "${NVIDIA_MODULE_PARAMS[@]}"; rc=$?
+[ $rc -ne 0 ] && { echo "[ERROR] modprobe nvidia failed: $rc"; exit 1; }
+modprobe -d "$INSTALL_DIR/$DRIVER_NAME" nvidia-uvm "${NVIDIA_UVM_MODULE_PARAMS[@]}"; rc=$?
+[ $rc -ne 0 ] && { echo "[ERROR] modprobe nvidia-uvm failed: $rc"; exit 1; }
 
 # Ensure device nodes exist on the host (idempotent, preferred over manual mknod)
 # -u: create /dev/nvidia-uvm

--- a/resources/install_fabricmanager.sh
+++ b/resources/install_fabricmanager.sh
@@ -21,10 +21,28 @@ if [[ "$GPU_NAME" =~ (A100|H100|H200|B100) ]]; then
   # Run Fabric Manager
   nv-fabricmanager -c /etc/fabricmanager.cfg
   echo "Fabric manager running"
-# For Blackwell architecture NVlink needs to be activated. nvidia-fabricmanager-start.sh starts NVLink 
+# For Blackwell architecture NVlink needs to be activated. nvidia-fabricmanager-start.sh starts NVLink
 elif [[ "$GPU_NAME" =~ B200 ]]; then
   sed 's/DAEMONIZE=1/DAEMONIZE=0/g' "/usr/share/nvidia/nvswitch/fabricmanager.cfg" > /etc/fabricmanager.cfg
   sed -i 's/LOG_FILE_NAME=.*$/LOG_FILE_NAME=/g' /etc/fabricmanager.cfg
+
+  # nvidia-fabricmanager-start.sh's NVL5 detection requires the ib_umad kernel
+  # module on the host. Load it via nsenter so it lands on the host kernel.
+  nsenter -t 1 -m -u -n -i modprobe ib_umad
+
+  # Mirror the host's /dev/infiniband umad/issm character devices into the
+  # container so nvlsm and nv-fabricmanager can open the InfiniBand management
+  # ports. Host /dev/infiniband is not propagated into the GPU Operator driver
+  # daemonset by default.
+  mkdir -p /dev/infiniband
+  while IFS= read -r dev_line; do
+    name=$(echo "$dev_line" | awk '{print $NF}')
+    major=$(echo "$dev_line" | awk '{print $5}' | tr -d ',')
+    minor=$(echo "$dev_line" | awk '{print $6}')
+    [ -z "$name" ] || [ -z "$major" ] || [ -z "$minor" ] && continue
+    [ -e "/dev/infiniband/$name" ] && continue
+    mknod "/dev/infiniband/$name" c "$major" "$minor" 2>/dev/null || true
+  done < <(nsenter -t 1 -m -u -n -i ls -la /dev/infiniband/ 2>/dev/null | grep -E '^c' | grep -E 'umad|issm')
 
   # Run Fabric Manager
   /usr/bin/nvidia-fabricmanager-start.sh --mode start --fm-config-file /etc/fabricmanager.cfg

--- a/resources/install_fabricmanager.sh
+++ b/resources/install_fabricmanager.sh
@@ -39,9 +39,13 @@ elif [[ "$GPU_NAME" =~ B200 ]]; then
     name=$(echo "$dev_line" | awk '{print $NF}')
     major=$(echo "$dev_line" | awk '{print $5}' | tr -d ',')
     minor=$(echo "$dev_line" | awk '{print $6}')
-    [ -z "$name" ] || [ -z "$major" ] || [ -z "$minor" ] && continue
+    # Validate name, major, and minor before creating any device node.
+    [[ "$name" =~ ^(umad|issm)[0-9]+$ ]] || continue
+    [[ "$major" =~ ^[0-9]+$ ]] || continue
+    [[ "$minor" =~ ^[0-9]+$ ]] || continue
     [ -e "/dev/infiniband/$name" ] && continue
-    mknod "/dev/infiniband/$name" c "$major" "$minor" 2>/dev/null || true
+    mknod "/dev/infiniband/$name" c "$major" "$minor" 2>/dev/null \
+      || echo "[WARN] mknod /dev/infiniband/$name ($major:$minor) failed — nvlsm may not be able to open InfiniBand management port" >&2
   done < <(nsenter -t 1 -m -u -n -i ls -la /dev/infiniband/ 2>/dev/null | grep -E '^c' | grep -E 'umad|issm')
 
   # Run Fabric Manager

--- a/resources/load_install_gpu_driver.sh
+++ b/resources/load_install_gpu_driver.sh
@@ -307,6 +307,7 @@ log() {
 }
 
 post_process() {
+  true
 }
 
 main "${@}"

--- a/resources/load_install_gpu_driver.sh
+++ b/resources/load_install_gpu_driver.sh
@@ -307,9 +307,6 @@ log() {
 }
 
 post_process() {
-    if ${DEBUG}; then
-        sleep infinity
-    fi
 }
 
 main "${@}"

--- a/resources/nvidia-uvm.conf
+++ b/resources/nvidia-uvm.conf
@@ -1,0 +1,1 @@
+uvm_disable_hmm=1


### PR DESCRIPTION
Port `_get_module_params` from `github.com/NVIDIA/gpu-driver-container` to `install.sh`, allowing operators to pass custom parameters to the `nvidia` and `nvidia-uvm` modules via conf files mounted at `/drivers/` (corresponding to the `driver.kernelModuleConfig` Helm value). Also copies a local `nvidia-uvm.conf` (`uvm_disable_hmm=1`) to `/drivers` without overwriting any operator-provided config, fixing an issue with B200 GPUs.

