### PR TITLE
fix: add containerd PATH drop-in for nvidia-container-cli discovery

### DIFF
--- a/nvidia-driver
+++ b/nvidia-driver
@@ -1,3 +1,4 @@
 #!/bin/bash
 /opt/nvidia-installer/load_install_gpu_driver.sh
 /opt/nvidia-installer/install_fabricmanager.sh
+/opt/nvidia-installer/install_containerd_path_dropin.sh

--- a/resources/install_containerd_path_dropin.sh
+++ b/resources/install_containerd_path_dropin.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck disable=SC2016
+# install_containerd_path_dropin.sh
+#
+# Installs a systemd drop-in for containerd that extends PATH to include
+# /opt/nvidia/toolkit. This is required for gVisor/runsc with nvproxy,
+# which uses exec.LookPath("nvidia-container-cli") and needs the binary
+# on containerd's PATH.
+#
+# The drop-in is written to the host filesystem. Containerd picks up the
+# new PATH on its next restart (which the GPU Operator's toolkit DaemonSet
+# triggers when it configures the container runtime).
+#
+# See: https://github.com/gardener/gardener-extension-runtime-gvisor/issues/411
+# See: https://github.com/NVIDIA/nvidia-container-toolkit/issues/1880
+
+set -e
+
+TOOLKIT_PATH="/opt/nvidia/toolkit"
+DROPIN_DIR="/etc/systemd/system/containerd.service.d"
+DROPIN_FILE="${DROPIN_DIR}/nvidia-toolkit-path.conf"
+
+install_containerd_path_dropin() {
+    echo "[INFO] Ensuring containerd PATH includes ${TOOLKIT_PATH}"
+    echo "[INFO] Drop-in target: ${DROPIN_FILE}"
+
+    if ! nsenter -t 1 -m -u -n -i /bin/sh -c '
+        DROPIN_DIR="'"${DROPIN_DIR}"'"
+        DROPIN_FILE="'"${DROPIN_FILE}"'"
+        TOOLKIT_PATH="'"${TOOLKIT_PATH}"'"
+
+        DROPIN_CONTENT="[Service]
+Environment=PATH=/var/bin/containerruntimes:${TOOLKIT_PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+"
+
+        if [ -f "${DROPIN_FILE}" ]; then
+            existing=$(cat "${DROPIN_FILE}")
+            if [ "${existing}" = "${DROPIN_CONTENT}" ]; then
+                echo "[INFO] containerd PATH drop-in already installed and up-to-date"
+                return 0
+            fi
+            echo "[INFO] containerd PATH drop-in exists but differs, updating"
+        fi
+
+        echo "[INFO] Installing containerd PATH drop-in to ${DROPIN_FILE}"
+        mkdir -p "${DROPIN_DIR}"
+        printf "%s" "${DROPIN_CONTENT}" > "${DROPIN_FILE}"
+        echo "[INFO] Running systemctl daemon-reload"
+        systemctl daemon-reload
+        echo "[INFO] Drop-in installed. Containerd will use the updated PATH on next restart."
+    '; then
+        echo "[ERROR] Failed to install containerd PATH drop-in (nsenter exited $?)"
+        echo "[ERROR] gVisor/runsc pods requiring nvidia-container-cli may fail to start"
+        return 1
+    fi
+
+    echo "[INFO] containerd PATH drop-in step completed successfully"
+}
+
+install_containerd_path_dropin


### PR DESCRIPTION
## What

Installs a systemd drop-in for containerd that extends `PATH` to include `/opt/nvidia/toolkit`, enabling gVisor/runsc with nvproxy to find `nvidia-container-cli` via `exec.LookPath`.

## Why

On Garden Linux, `/usr` is read-only, so the NVIDIA Container Toolkit is installed to `/opt/nvidia/toolkit/` (via `toolkit.installDir` in GPU Operator values). Unlike runc — which resolves the CLI path from its config TOML — runsc uses `exec.LookPath("nvidia-container-cli")`, which relies on the calling process (containerd) having the binary on its PATH.

Without this fix, gVisor pods with GPU access fail at startup:

```
nvidia-container-cli: exec: "nvidia-container-cli": executable file not found in $PATH
```

## How

- New script `resources/install_containerd_path_dropin.sh` writes a systemd drop-in at `/etc/systemd/system/containerd.service.d/nvidia-toolkit-path.conf` on the host via `nsenter`
- Runs `systemctl daemon-reload` so containerd picks up the new PATH on its next restart
- Does **not** restart containerd (the GPU Operator toolkit DaemonSet already does this when it configures the container runtime)
- Idempotent: skips if the drop-in is already present and up-to-date
- Called as the last step in the `nvidia-driver` entrypoint

## Status

> **Still testing**  this is a draft while I validate the fix on a cluster.

## References

- https://github.com/gardener/gardener-extension-runtime-gvisor/issues/411
- https://github.com/NVIDIA/nvidia-container-toolkit/issues/1880
