### PR TITLE
Extract inline workflow bash into testable .ci/ scripts

### DIFF
--- a/.ci/git_ops.sh
+++ b/.ci/git_ops.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Git commit and PR creation helpers used by the release pipeline.
+# Sourced by CI steps and bats tests — not executed directly.
+#
+# Required env for create_pr:
+#   GH_TOKEN    for gh cli
+set -euo pipefail
+
+# configure_git_identity NAME EMAIL
+# Sets git user.name and user.email (local, not --global).
+configure_git_identity() {
+    local name="$1"
+    local email="$2"
+    git config user.name "$name"
+    git config user.email "$email"
+}
+
+# commit_and_push_branch BRANCH FILES...
+# Stages FILES, exits 0 with a message if nothing to commit, otherwise
+# checks out BRANCH, commits, and force-pushes to origin.
+commit_and_push_branch() {
+    local branch="$1"
+    shift
+    git add "$@"
+    if git diff --cached --quiet --exit-code; then
+        echo "No changes to commit"
+        return 0
+    fi
+    git checkout -b "$branch"
+    git commit -m "Update release references for $branch"
+    git push -f origin "$branch"
+}
+
+# create_pr BRANCH BASE TITLE BODY
+# Creates a GitHub PR from BRANCH into BASE.
+create_pr() {
+    local branch="$1"
+    local base="$2"
+    local title="$3"
+    local body="$4"
+    gh pr create --base "$base" --head "$branch" --title "$title" --body "$body"
+}

--- a/.ci/helm_test.sh
+++ b/.ci/helm_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Helm test result evaluation for test_installer CI job.
+# Sourced by CI steps and bats tests — not executed directly.
+set -euo pipefail
+
+# evaluate_helm_test_output LOG_FILE HELM_EXIT_CODE
+# Returns 0 if tests passed, 1 on any failure.
+# Pure function — reads the log file, no helm or kubectl calls.
+evaluate_helm_test_output() {
+    local log_file="$1"
+    local helm_exit_code="$2"
+
+    if [[ ! -f "$log_file" ]]; then
+        echo "Log file not found: $log_file"
+        return 1
+    fi
+
+    if grep -q "FAILED" "$log_file" || grep -q "Error" "$log_file"; then
+        echo "Test output indicates failure"
+        return 1
+    fi
+
+    if [[ "$helm_exit_code" -ne 0 ]]; then
+        echo "Helm test command failed with exit code: $helm_exit_code"
+        return 1
+    fi
+
+    return 0
+}
+
+# check_pod_statuses NAMESPACE LABEL_SELECTOR
+# Iterates all pods matching LABEL_SELECTOR in NAMESPACE.
+# Returns 1 if any pod is not in Succeeded phase.
+check_pod_statuses() {
+    local namespace="$1"
+    local selector="$2"
+
+    local pods
+    # shellcheck disable=SC2086
+    pods=$(kubectl get pods -n "$namespace" -l "$selector" \
+        -o jsonpath='{.items[*].metadata.name}')
+
+    local pod status
+    for pod in $pods; do
+        status=$(kubectl get pod "$pod" -n "$namespace" \
+            -o jsonpath='{.status.phase}')
+        if [[ "$status" != "Succeeded" ]]; then
+            echo "Test pod $pod failed with status: $status"
+            return 1
+        fi
+    done
+}

--- a/.ci/image_folder.sh
+++ b/.ci/image_folder.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Resolves IMAGE_FOLDER and IMAGE_FOLDER_OLD for the build_image CI job.
+# Sourced by CI steps and bats tests — not executed directly.
+#
+# Required env:
+#   GH_REPO          github.repository (e.g. "gardenlinux/gardenlinux-nvidia-installer")
+#   GH_TOKEN         for gh cli
+#   GITHUB_OUTPUT    path to GHA output file; defaults to /dev/null when unset
+set -euo pipefail
+
+# get_tag_from_release_update_branch
+# Prints the version tag from the latest release-update/* branch, or empty if none exists.
+get_tag_from_release_update_branch() {
+    git ls-remote --heads origin 'release-update*' | head -n 1 | cut -f2 | cut -d/ -f4
+}
+
+# get_latest_release_tag
+# Queries GitHub releases and prints the latest X.Y.Z tag, or empty if none exists.
+get_latest_release_tag() {
+    gh release list --repo "$GH_REPO" --json tagName \
+        --jq '[.[] | select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first | .tagName // empty'
+}
+
+# resolve_image_folders TAG OLD_TAG
+# Prints IMAGE_FOLDER and IMAGE_FOLDER_OLD as KEY=VALUE lines.
+# IMAGE_FOLDER_OLD is only set for patch releases (same MAJOR.MINOR); empty otherwise.
+resolve_image_folders() {
+    local tag="$1"
+    local old_tag="$2"
+    local major minor old_major old_minor image_folder image_folder_old
+
+    major=$(echo "$tag" | cut -d. -f1)
+    minor=$(echo "$tag" | cut -d. -f2)
+    old_major=$(echo "$old_tag" | cut -d. -f1)
+    old_minor=$(echo "$old_tag" | cut -d. -f2)
+
+    image_folder=$(echo "/${tag}" | tr '[:upper:]' '[:lower:]')
+
+    if [[ "$major" == "$old_major" && "$minor" == "$old_minor" ]]; then
+        image_folder_old=$(echo "/${old_tag}" | tr '[:upper:]' '[:lower:]')
+    else
+        image_folder_old=""
+    fi
+
+    echo "image_folder=${image_folder}"
+    echo "image_folder_old=${image_folder_old}"
+}
+
+# main
+# Orchestrates the above and writes outputs to ${GITHUB_OUTPUT:-/dev/null}.
+main() {
+    local tag old_tag
+    tag=$(get_tag_from_release_update_branch)
+    old_tag=$(get_latest_release_tag)
+
+    local image_folder image_folder_old
+    while IFS='=' read -r key value; do
+        case "$key" in
+            image_folder)     image_folder="$value" ;;
+            image_folder_old) image_folder_old="$value" ;;
+        esac
+    done < <(resolve_image_folders "$tag" "$old_tag")
+
+    echo "image_folder_old: ${image_folder_old}"
+    echo "image_folder: ${image_folder}"
+
+    echo "image_folder_old=${image_folder_old}" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "image_folder=${image_folder}" >> "${GITHUB_OUTPUT:-/dev/null}"
+}

--- a/.ci/matrix_outputs.sh
+++ b/.ci/matrix_outputs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Runs generate_matrix.py and writes all matrix outputs to GITHUB_OUTPUT.
+# Must be run from repo root (generate_matrix.py reads ./versions.yaml).
+# Sourced by CI steps — not executed directly.
+#
+# Required env:
+#   GITHUB_OUTPUT    path to GHA output file; defaults to /dev/null when unset
+set -euo pipefail
+
+# write_matrix_outputs
+# Generates the build/manifest matrices and driver versions, writing all to GITHUB_OUTPUT.
+write_matrix_outputs() {
+    local matrix_json driver_versions
+    matrix_json=$(python3 .ci/generate_matrix.py)
+    driver_versions=$(yq -o=json '.nvidia_drivers' versions.yaml | jq -c '.')
+
+    echo "build_matrix=$(echo "$matrix_json" | jq -c '.build')" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "manifest_matrix=$(echo "$matrix_json" | jq -c '.manifest')" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "gvisor_build_matrix=$(echo "$matrix_json" | jq -c '.gvisor_build')" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "gvisor_manifest_matrix=$(echo "$matrix_json" | jq -c '.gvisor_manifest')" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "driver_versions=${driver_versions}" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "Driver versions: ${driver_versions}"
+}

--- a/.ci/release_branches.sh
+++ b/.ci/release_branches.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Release branch management for the create-gh-release CI job.
+# Sourced by CI steps — not executed directly.
+set -euo pipefail
+
+# update_release_branches MAJOR MINOR
+# Merges main into the MAJOR.MINOR and MAJOR release branches and pushes both.
+update_release_branches() {
+    local major="$1"
+    local minor="$2"
+    local branch
+
+    branch="${major}.${minor}"
+    git checkout -B "$branch" "origin/${branch}" || git checkout -b "$branch"
+    git merge main --no-edit
+    git push origin "$branch"
+
+    branch="${major}"
+    git checkout -B "$branch" "origin/${branch}" || git checkout -b "$branch"
+    git merge main --no-edit
+    git push origin "$branch"
+}

--- a/.ci/semver.sh
+++ b/.ci/semver.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Semver bump logic for the release pipeline.
+# Sourced by CI steps and bats tests — not executed directly.
+#
+# Required env:
+#   GH_REPO          github.repository (e.g. "gardenlinux/gardenlinux-nvidia-installer")
+#   GH_TOKEN         for gh cli
+#   GITHUB_OUTPUT    path to GHA output file; defaults to /dev/null when unset
+set -euo pipefail
+
+# parse_semver TAG
+# Sets MAJOR, MINOR, PATCH in the caller's scope.
+parse_semver() {
+    local tag="$1"
+    MAJOR=$(echo "$tag" | cut -d. -f1)
+    MINOR=$(echo "$tag" | cut -d. -f2)
+    PATCH=$(echo "$tag" | cut -d. -f3)
+}
+
+# extract_yaml_section REF SECTION
+# Prints the list items under SECTION from versions.yaml at the given git REF.
+extract_yaml_section() {
+    local ref="$1"
+    local section="$2"
+    { git show "${ref}:versions.yaml" 2>/dev/null || true; } \
+        | awk "/^${section}:/{found=1; next} found && /^[^ -]/{exit} found{print}"
+}
+
+# count_added BEFORE AFTER
+# Prints the number of lines present in AFTER that are not in BEFORE.
+count_added() {
+    local before="$1"
+    local after="$2"
+    local f1 f2 result
+    f1=$(mktemp)
+    f2=$(mktemp)
+    [ -n "$before" ] && printf "%s\n" "$before" > "$f1" || true
+    [ -n "$after"  ] && printf "%s\n" "$after"  > "$f2" || true
+    result=$(diff "$f1" "$f2" | grep -c '^>' || true)
+    rm -f "$f1" "$f2"
+    echo "$result"
+}
+
+# _versions_yaml_without_os_versions REF
+# Prints versions.yaml at REF with the os_versions list stripped out.
+_versions_yaml_without_os_versions() {
+    local ref="$1"
+    { git show "${ref}:versions.yaml" 2>/dev/null || true; } \
+        | awk '/^os_versions:/{skip=1; next} skip && !/^  -/{skip=0} !skip'
+}
+
+# bump_semver
+# Determines and outputs the next semver tag.
+# Reads GH_REPO from env; writes new_tag=X.Y.Z to ${GITHUB_OUTPUT:-/dev/null}.
+bump_semver() {
+    local last_tag new_tag
+    local major minor patch
+    local nvidia_before nvidia_after os_before os_after
+    local nvidia_added versions_yaml_before_no_os versions_yaml_after_no_os
+    local versions_yaml_other_changes other_files_changed
+
+    last_tag=$(gh release list --repo "$GH_REPO" --json tagName \
+        --jq '[.[] | select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first | .tagName // empty')
+
+    if [[ -z "$last_tag" ]]; then
+        echo "No previous release found, starting at 1.0.0"
+        new_tag="1.0.0"
+        echo "new_tag=${new_tag}" >> "${GITHUB_OUTPUT:-/dev/null}"
+        return 0
+    fi
+
+    parse_semver "$last_tag"
+    major="$MAJOR"
+    minor="$MINOR"
+    patch="$PATCH"
+
+    nvidia_before=$(extract_yaml_section "$last_tag" "nvidia_drivers")
+    nvidia_after=$(extract_yaml_section "HEAD" "nvidia_drivers")
+    os_before=$(extract_yaml_section "$last_tag" "os_versions")
+    os_after=$(extract_yaml_section "HEAD" "os_versions")
+
+    nvidia_added=$(count_added "$nvidia_before" "$nvidia_after")
+
+    versions_yaml_before_no_os=$(_versions_yaml_without_os_versions "$last_tag")
+    versions_yaml_after_no_os=$(_versions_yaml_without_os_versions "HEAD")
+    versions_yaml_other_changes=$(count_added "$versions_yaml_before_no_os" "$versions_yaml_after_no_os")
+
+    other_files_changed=$(git diff --name-only "${last_tag}..HEAD" \
+        | grep -cv \
+            -e '^versions\.yaml$' \
+            -e '^\.github/' \
+            -e '^\.ci/' \
+            -e '^cdup/' \
+            -e '^docs/' \
+            -e '^history\.yaml$' \
+        || true)
+
+    if [[ "$nvidia_added" -gt 0 ]] || [[ "$other_files_changed" -gt 0 ]] || [[ "$versions_yaml_other_changes" -gt 0 ]]; then
+        echo "NVIDIA_ADDED: ${nvidia_added}, OTHER_FILES_CHANGED: ${other_files_changed}, VERSIONS_YAML_OTHER_CHANGES: ${versions_yaml_other_changes}"
+        minor=$((minor + 1))
+        patch=0
+    else
+        patch=$((patch + 1))
+    fi
+
+    new_tag="${major}.${minor}.${patch}"
+    echo "Last tag: ${last_tag} → New tag: ${new_tag}"
+    echo "new_tag=${new_tag}" >> "${GITHUB_OUTPUT:-/dev/null}"
+}

--- a/.ci/test/test_git_ops.bats
+++ b/.ci/test/test_git_ops.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+#
+# Tests for functions in .ci/git_ops.sh
+#
+# Run from repo root: test/bats/bin/bats test/bats/test_git_ops.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/.ci/git_ops.sh"
+
+load "${REPO_ROOT}/test/test_helper/bats-support/load"
+load "${REPO_ROOT}/test/test_helper/bats-assert/load"
+
+setup() {
+    GIT_CALLS=()
+    git() { GIT_CALLS+=("$*"); }
+    gh() { echo "https://github.com/test/repo/pull/1"; }
+    # shellcheck disable=SC1090
+    . "${SCRIPT}"
+}
+
+# ---------------------------------------------------------------------------
+# configure_git_identity
+# ---------------------------------------------------------------------------
+
+@test "configure_git_identity: calls git config user.name" {
+    configure_git_identity "Garden Linux Builder" "builder@example.com"
+    local found=false
+    for call in "${GIT_CALLS[@]}"; do
+        [[ "$call" == "config user.name Garden Linux Builder" ]] && found=true
+    done
+    assert_equal "$found" "true"
+}
+
+@test "configure_git_identity: calls git config user.email" {
+    configure_git_identity "Garden Linux Builder" "builder@example.com"
+    local found=false
+    for call in "${GIT_CALLS[@]}"; do
+        [[ "$call" == "config user.email builder@example.com" ]] && found=true
+    done
+    assert_equal "$found" "true"
+}
+
+@test "configure_git_identity: does not use --global flag" {
+    configure_git_identity "Garden Linux Builder" "builder@example.com"
+    for call in "${GIT_CALLS[@]}"; do
+        if [[ "$call" == *"--global"* ]]; then
+            fail "git config was called with --global: $call"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# commit_and_push_branch
+# ---------------------------------------------------------------------------
+
+@test "commit_and_push_branch: exits 0 with message when nothing staged" {
+    # git add is a no-op; git diff --cached --quiet exits 0 (nothing staged)
+    git() {
+        case "$*" in
+            "add some-file.yaml") ;;
+            "diff --cached --quiet --exit-code") return 0 ;;
+            *) ;;
+        esac
+    }
+    run commit_and_push_branch "my-branch" "some-file.yaml"
+    assert_success
+    assert_output --partial "No changes to commit"
+}
+
+@test "commit_and_push_branch: commits and force-pushes when changes are staged" {
+    PUSH_CALLED=false
+    git() {
+        case "$*" in
+            "add file-a.yaml file-b.yaml") ;;
+            "diff --cached --quiet --exit-code") return 1 ;;
+            "checkout -b release-update/1.2.0") ;;
+            "commit -m Update release references for release-update/1.2.0") ;;
+            "push -f origin release-update/1.2.0") PUSH_CALLED=true ;;
+            *) ;;
+        esac
+    }
+    commit_and_push_branch "release-update/1.2.0" "file-a.yaml" "file-b.yaml"
+    assert_equal "$PUSH_CALLED" "true"
+}

--- a/.ci/test/test_helm_test.bats
+++ b/.ci/test/test_helm_test.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+#
+# Tests for functions in .ci/helm_test.sh
+#
+# Run from repo root: test/bats/bin/bats test/bats/test_helm_test.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/.ci/helm_test.sh"
+
+load "${REPO_ROOT}/test/test_helper/bats-support/load"
+load "${REPO_ROOT}/test/test_helper/bats-assert/load"
+
+setup() {
+    kubectl() { echo ""; }
+    # shellcheck disable=SC1090
+    . "${SCRIPT}"
+    LOG_FILE="${BATS_TEST_TMPDIR}/test-output.log"
+}
+
+# ---------------------------------------------------------------------------
+# evaluate_helm_test_output
+# ---------------------------------------------------------------------------
+
+@test "evaluate_helm_test_output: clean log and exit 0 passes" {
+    echo "Suite passed" > "$LOG_FILE"
+    run evaluate_helm_test_output "$LOG_FILE" 0
+    assert_success
+}
+
+@test "evaluate_helm_test_output: FAILED in log causes failure" {
+    echo "FAILED: some-test" > "$LOG_FILE"
+    run evaluate_helm_test_output "$LOG_FILE" 0
+    assert_failure
+    assert_output --partial "Test output indicates failure"
+}
+
+@test "evaluate_helm_test_output: Error in log causes failure" {
+    echo "Error running pod" > "$LOG_FILE"
+    run evaluate_helm_test_output "$LOG_FILE" 0
+    assert_failure
+    assert_output --partial "Test output indicates failure"
+}
+
+@test "evaluate_helm_test_output: non-zero exit code causes failure" {
+    echo "Suite passed" > "$LOG_FILE"
+    run evaluate_helm_test_output "$LOG_FILE" 1
+    assert_failure
+    assert_output --partial "exit code: 1"
+}
+
+@test "evaluate_helm_test_output: missing log file causes failure" {
+    run evaluate_helm_test_output "/nonexistent/path.log" 0
+    assert_failure
+    assert_output --partial "Log file not found"
+}
+
+# ---------------------------------------------------------------------------
+# check_pod_statuses
+# ---------------------------------------------------------------------------
+
+@test "check_pod_statuses: all Succeeded pods pass" {
+    kubectl() {
+        case "$*" in
+            "get pods -n gpu-operator -l app=test -o jsonpath={.items[*].metadata.name}")
+                echo "pod-a pod-b" ;;
+            "get pod pod-a -n gpu-operator -o jsonpath={.status.phase}")
+                echo "Succeeded" ;;
+            "get pod pod-b -n gpu-operator -o jsonpath={.status.phase}")
+                echo "Succeeded" ;;
+        esac
+    }
+    run check_pod_statuses "gpu-operator" "app=test"
+    assert_success
+}
+
+@test "check_pod_statuses: Failed pod causes failure with pod name" {
+    kubectl() {
+        case "$*" in
+            "get pods -n gpu-operator -l app=test -o jsonpath={.items[*].metadata.name}")
+                echo "pod-a" ;;
+            "get pod pod-a -n gpu-operator -o jsonpath={.status.phase}")
+                echo "Failed" ;;
+        esac
+    }
+    run check_pod_statuses "gpu-operator" "app=test"
+    assert_failure
+    assert_output --partial "pod-a"
+    assert_output --partial "Failed"
+}
+
+@test "check_pod_statuses: no matching pods passes" {
+    kubectl() {
+        case "$*" in
+            "get pods -n gpu-operator -l app=test -o jsonpath={.items[*].metadata.name}")
+                echo "" ;;
+        esac
+    }
+    run check_pod_statuses "gpu-operator" "app=test"
+    assert_success
+}

--- a/.ci/test/test_image_folder.bats
+++ b/.ci/test/test_image_folder.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# Tests for functions in .ci/image_folder.sh
+#
+# Run from repo root: test/bats/bin/bats test/bats/test_image_folder.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/.ci/image_folder.sh"
+
+load "${REPO_ROOT}/test/test_helper/bats-support/load"
+load "${REPO_ROOT}/test/test_helper/bats-assert/load"
+
+setup() {
+    git() { echo ""; }
+    gh() { echo ""; }
+    GH_REPO="test/repo"
+    # shellcheck disable=SC1090
+    . "${SCRIPT}"
+}
+
+# ---------------------------------------------------------------------------
+# resolve_image_folders
+# ---------------------------------------------------------------------------
+
+@test "resolve_image_folders: same MAJOR.MINOR sets IMAGE_FOLDER_OLD" {
+    run resolve_image_folders "1.5.1" "1.5.0"
+    assert_success
+    assert_output --partial "image_folder_old=/1.5.0"
+    assert_output --partial "image_folder=/1.5.1"
+}
+
+@test "resolve_image_folders: different MINOR clears IMAGE_FOLDER_OLD" {
+    run resolve_image_folders "1.6.0" "1.5.9"
+    assert_success
+    assert_output --partial "image_folder_old="
+    assert_output --partial "image_folder=/1.6.0"
+    # Confirm image_folder_old is truly empty (not set to the old path)
+    refute_output --partial "image_folder_old=/1.5"
+}
+
+@test "resolve_image_folders: different MAJOR clears IMAGE_FOLDER_OLD" {
+    run resolve_image_folders "2.0.0" "1.9.3"
+    assert_success
+    refute_output --partial "image_folder_old=/1"
+    assert_output --partial "image_folder=/2.0.0"
+}
+
+@test "resolve_image_folders: tag is lowercased in IMAGE_FOLDER" {
+    run resolve_image_folders "1.5.0-RC1" "1.4.9"
+    assert_success
+    assert_output --partial "image_folder=/1.5.0-rc1"
+    refute_output --partial "image_folder=/1.5.0-RC1"
+}
+
+@test "resolve_image_folders: same tag (exact rebuild) sets IMAGE_FOLDER_OLD" {
+    run resolve_image_folders "1.5.0" "1.5.0"
+    assert_success
+    assert_output --partial "image_folder_old=/1.5.0"
+    assert_output --partial "image_folder=/1.5.0"
+}
+
+# ---------------------------------------------------------------------------
+# get_tag_from_release_update_branch
+# ---------------------------------------------------------------------------
+
+@test "get_tag_from_release_update_branch: extracts version from branch ref" {
+    git() {
+        echo "abc123	refs/heads/release-update/1.6.0"
+    }
+    run get_tag_from_release_update_branch
+    assert_success
+    assert_output "1.6.0"
+}
+
+@test "get_tag_from_release_update_branch: uses only first line when multiple branches" {
+    git() {
+        printf "abc123\trefs/heads/release-update/1.6.0\n"
+        printf "def456\trefs/heads/release-update/1.5.1\n"
+    }
+    run get_tag_from_release_update_branch
+    assert_success
+    assert_output "1.6.0"
+}
+
+@test "get_tag_from_release_update_branch: returns empty when no release-update branch" {
+    git() { echo ""; }
+    run get_tag_from_release_update_branch
+    assert_success
+    assert_output ""
+}

--- a/.ci/test/test_semver.bats
+++ b/.ci/test/test_semver.bats
@@ -1,0 +1,319 @@
+#!/usr/bin/env bats
+#
+# Tests for functions in .ci/semver.sh
+#
+# Run from repo root: test/bats/bin/bats test/bats/test_semver.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/.ci/semver.sh"
+
+load "${REPO_ROOT}/test/test_helper/bats-support/load"
+load "${REPO_ROOT}/test/test_helper/bats-assert/load"
+
+setup() {
+    # Stub external commands; tests override as needed
+    git() { echo ""; }
+    gh() { echo ""; }
+    # shellcheck disable=SC1090
+    . "${SCRIPT}"
+}
+
+# ---------------------------------------------------------------------------
+# parse_semver
+# ---------------------------------------------------------------------------
+
+@test "parse_semver: parses 1.0.0" {
+    parse_semver "1.0.0"
+    assert_equal "$MAJOR" "1"
+    assert_equal "$MINOR" "0"
+    assert_equal "$PATCH" "0"
+}
+
+@test "parse_semver: parses 10.23.456" {
+    parse_semver "10.23.456"
+    assert_equal "$MAJOR" "10"
+    assert_equal "$MINOR" "23"
+    assert_equal "$PATCH" "456"
+}
+
+@test "parse_semver: parses 0.0.0" {
+    parse_semver "0.0.0"
+    assert_equal "$MAJOR" "0"
+    assert_equal "$MINOR" "0"
+    assert_equal "$PATCH" "0"
+}
+
+# ---------------------------------------------------------------------------
+# count_added
+# ---------------------------------------------------------------------------
+
+@test "count_added: identical input returns 0" {
+    result=$(count_added "alpha
+beta" "alpha
+beta")
+    assert_equal "$result" "0"
+}
+
+@test "count_added: one line added returns 1" {
+    result=$(count_added "alpha" "alpha
+beta")
+    assert_equal "$result" "1"
+}
+
+@test "count_added: multiple added returns correct count" {
+    result=$(count_added "alpha" "alpha
+beta
+gamma")
+    assert_equal "$result" "2"
+}
+
+@test "count_added: empty before returns full count of after" {
+    result=$(count_added "" "alpha
+beta")
+    assert_equal "$result" "2"
+}
+
+@test "count_added: empty after returns 0" {
+    result=$(count_added "alpha
+beta" "")
+    assert_equal "$result" "0"
+}
+
+# ---------------------------------------------------------------------------
+# extract_yaml_section
+# ---------------------------------------------------------------------------
+
+@test "extract_yaml_section: extracts nvidia_drivers list" {
+    git() {
+        printf "nvidia_drivers:\n  - 570\n  - 560\nos_versions:\n  - 1877\n"
+    }
+    result=$(extract_yaml_section "HEAD" "nvidia_drivers")
+    assert_equal "$result" "  - 570
+  - 560"
+}
+
+@test "extract_yaml_section: extracts os_versions list" {
+    git() {
+        printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n  - 2150\n"
+    }
+    result=$(extract_yaml_section "HEAD" "os_versions")
+    assert_equal "$result" "  - 1877
+  - 2150"
+}
+
+@test "extract_yaml_section: returns all items in a longer list" {
+    git() {
+        printf "nvidia_drivers:\n  - 570\n  - 560\n  - 550\n  - 535\nos_versions:\n  - 1877\n"
+    }
+    result=$(extract_yaml_section "HEAD" "nvidia_drivers")
+    assert_equal "$result" "  - 570
+  - 560
+  - 550
+  - 535"
+}
+
+@test "extract_yaml_section: returns all items when section is last in file" {
+    git() {
+        printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n  - 2150\n  - 2200\n"
+    }
+    result=$(extract_yaml_section "HEAD" "os_versions")
+    assert_equal "$result" "  - 1877
+  - 2150
+  - 2200"
+}
+
+@test "extract_yaml_section: stops at next top-level key" {
+    git() {
+        printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\ngvisor_version: 20240101\n"
+    }
+    result=$(extract_yaml_section "HEAD" "os_versions")
+    assert_equal "$result" "  - 1877"
+}
+
+@test "extract_yaml_section: returns empty string for missing section" {
+    git() {
+        printf "nvidia_drivers:\n  - 570\n"
+    }
+    result=$(extract_yaml_section "HEAD" "os_versions")
+    assert_equal "$result" ""
+}
+
+@test "extract_yaml_section: returns empty string when git show fails" {
+    git() { return 1; }
+    result=$(extract_yaml_section "nosuchref" "nvidia_drivers")
+    assert_equal "$result" ""
+}
+
+# ---------------------------------------------------------------------------
+# bump_semver — no previous release
+# ---------------------------------------------------------------------------
+
+@test "bump_semver: no previous release produces 1.0.0" {
+    gh() { echo ""; }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=1.0.0" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+@test "bump_semver: no previous release writes to GITHUB_OUTPUT" {
+    gh() { echo ""; }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=1.0.0" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+@test "bump_semver: GITHUB_OUTPUT unset falls back to /dev/null without error" {
+    gh() { echo ""; }
+    unset GITHUB_OUTPUT
+    GH_REPO="test/repo"
+    run bump_semver
+    assert_success
+}
+
+# ---------------------------------------------------------------------------
+# bump_semver — MINOR bump triggers
+# ---------------------------------------------------------------------------
+
+@test "bump_semver: NVIDIA driver added causes MINOR bump" {
+    gh() { echo "2.5.3"; }
+    git() {
+        case "$*" in
+            "show 2.5.3:versions.yaml") printf "nvidia_drivers:\n  - 570\n  - 560\n" ;;
+            "show HEAD:versions.yaml")  printf "nvidia_drivers:\n  - 570\n  - 560\n  - 550\nos_versions:\n  - 1877\n" ;;
+            "diff --name-only 2.5.3..HEAD") echo "versions.yaml" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=2.6.0" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+@test "bump_semver: other files changed causes MINOR bump" {
+    gh() { echo "1.3.2"; }
+    git() {
+        case "$*" in
+            "show 1.3.2:versions.yaml") printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n" ;;
+            "show HEAD:versions.yaml")  printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n" ;;
+            "diff --name-only 1.3.2..HEAD") printf "Makefile\nresources/compile.sh\n" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=1.4.0" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+@test "bump_semver: versions.yaml non-os_versions change causes MINOR bump" {
+    gh() { echo "1.2.0"; }
+    git() {
+        case "$*" in
+            "show 1.2.0:versions.yaml") printf "nvidia_drivers:\n  - 570\ngvisor_version: 20240101\nos_versions:\n  - 1877\n" ;;
+            "show HEAD:versions.yaml")  printf "nvidia_drivers:\n  - 570\ngvisor_version: 20250101\nos_versions:\n  - 1877\n" ;;
+            "diff --name-only 1.2.0..HEAD") echo "versions.yaml" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=1.3.0" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+# ---------------------------------------------------------------------------
+# bump_semver — PATCH bump (os_versions only)
+# ---------------------------------------------------------------------------
+
+@test "bump_semver: only os_versions changed causes PATCH bump" {
+    gh() { echo "2.5.3"; }
+    git() {
+        case "$*" in
+            "show 2.5.3:versions.yaml") printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n" ;;
+            "show HEAD:versions.yaml")  printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n  - 2150\n" ;;
+            "diff --name-only 2.5.3..HEAD") echo "versions.yaml" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=2.5.4" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+@test "bump_semver: patch increment from 99 does not overflow" {
+    gh() { echo "1.0.99"; }
+    git() {
+        case "$*" in
+            "show 1.0.99:versions.yaml") printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n" ;;
+            "show HEAD:versions.yaml")   printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n  - 2150\n" ;;
+            "diff --name-only 1.0.99..HEAD") echo "versions.yaml" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=1.0.100" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+# ---------------------------------------------------------------------------
+# bump_semver — MINOR bump resets PATCH
+# ---------------------------------------------------------------------------
+
+@test "bump_semver: MINOR bump resets PATCH to 0" {
+    gh() { echo "1.5.99"; }
+    git() {
+        case "$*" in
+            "show 1.5.99:versions.yaml") printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n" ;;
+            "show HEAD:versions.yaml")   printf "nvidia_drivers:\n  - 570\n  - 560\nos_versions:\n  - 1877\n" ;;
+            "diff --name-only 1.5.99..HEAD") echo "versions.yaml" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=1.6.0" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}
+
+# ---------------------------------------------------------------------------
+# bump_semver — exclusion list
+# ---------------------------------------------------------------------------
+
+@test "bump_semver: changes only in .github/ excluded, causes PATCH bump" {
+    gh() { echo "3.1.0"; }
+    git() {
+        case "$*" in
+            "show 3.1.0:versions.yaml") printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n" ;;
+            "show HEAD:versions.yaml")  printf "nvidia_drivers:\n  - 570\nos_versions:\n  - 1877\n  - 2150\n" ;;
+            "diff --name-only 3.1.0..HEAD") printf ".github/workflows/release-process.yml\nversions.yaml\n" ;;
+            *) echo "" ;;
+        esac
+    }
+    GITHUB_OUTPUT="$(mktemp)"
+    GH_REPO="test/repo"
+    bump_semver
+    run grep "new_tag=3.1.1" "$GITHUB_OUTPUT"
+    assert_success
+    rm -f "$GITHUB_OUTPUT"
+}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -37,35 +37,11 @@ jobs:
 
       - name: Get image folder
         id: get-image-folder
+        env:
+          GH_REPO: ${{ github.repository }}
         run: |
-          # Get the to-be-built release version, based on the latest release-update branch
-          TAG=$(git ls-remote --heads origin 'release-update*' | head -n 1 | cut -f2 | cut -d/ -f4)
-          
-          # Get the previous version, based on the latest release tag
-          OLD_TAG=$(gh release list --repo "${{ github.repository }}" --json tagName \
-            --jq '[.[] | select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first | .tagName // empty')
-
-          MAJOR=$(echo "$TAG" | cut -d. -f1)
-          MINOR=$(echo "$TAG" | cut -d. -f2)
-          PATCH=$(echo "$TAG" | cut -d. -f3)
-
-          OLD_MAJOR=$(echo "$OLD_TAG" | cut -d. -f1)
-          OLD_MINOR=$(echo "$OLD_TAG" | cut -d. -f2)
-
-          # We only look at the previous folder in the case of a patch release - for minor and major releases
-          #  we build all images from scratch, so there is no old folder to pull from and IMAGE_FOLDER_OLD should be empty
-          if [[ "$MAJOR" == "$OLD_MAJOR" && "$MINOR" == "$OLD_MINOR" ]]; then
-            IMAGE_FOLDER_OLD=$(echo "/${OLD_TAG}" | tr '[:upper:]' '[:lower:]')
-          else
-            IMAGE_FOLDER_OLD=""
-          fi
-          IMAGE_FOLDER=$(echo "/${TAG}" | tr '[:upper:]' '[:lower:]')
-
-          echo "image_folder_old: ${IMAGE_FOLDER_OLD}"
-          echo "image_folder: ${IMAGE_FOLDER}"
-
-          echo "image_folder_old=${IMAGE_FOLDER_OLD}" >> $GITHUB_OUTPUT
-          echo "image_folder=${IMAGE_FOLDER}" >> $GITHUB_OUTPUT
+          source .ci/image_folder.sh
+          main
 
 
   generate-matrix:
@@ -92,15 +68,8 @@ jobs:
       - name: Generate build and manifest matrices
         id: set-matrix
         run: |
-          MATRIX_JSON=$(python3 .ci/generate_matrix.py)
-          echo "build_matrix=$(echo "$MATRIX_JSON" | jq -c '.build')" >> $GITHUB_OUTPUT
-          echo "manifest_matrix=$(echo "$MATRIX_JSON" | jq -c '.manifest')" >> $GITHUB_OUTPUT
-          echo "gvisor_build_matrix=$(echo "$MATRIX_JSON" | jq -c '.gvisor_build')" >> $GITHUB_OUTPUT
-          echo "gvisor_manifest_matrix=$(echo "$MATRIX_JSON" | jq -c '.gvisor_manifest')" >> $GITHUB_OUTPUT
-          # Output unique driver versions as a JSON array
-          DRIVER_VERSIONS=$(yq -o=json '.nvidia_drivers' versions.yaml | jq -c '.')
-          echo "driver_versions=$DRIVER_VERSIONS" >> $GITHUB_OUTPUT
-          echo "Driver versions: $DRIVER_VERSIONS"
+          source .ci/matrix_outputs.sh
+          write_matrix_outputs
 
   test-shell:
     runs-on: ubuntu-latest
@@ -110,7 +79,13 @@ jobs:
           submodules: true
 
       - name: Run bats tests
-        run: test/bats/bin/bats dynamic_compilation/test_resolve_driver_version.bats
+        run: |
+          test/bats/bin/bats \
+            dynamic_compilation/test_resolve_driver_version.bats \
+            .ci/test/test_semver.bats \
+            .ci/test/test_image_folder.bats \
+            .ci/test/test_helm_test.bats \
+            .ci/test/test_git_ops.bats
 
   build-runtime-driver-image:
     needs: [generate-matrix, image-folder, test-shell]

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -28,25 +28,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          source .ci/semver.sh
+          source .ci/release_branches.sh
           release_tag=$(cat release-version.yaml)
-          
-          MAJOR=$(echo "$release_tag" | cut -d. -f1)
-          MINOR=$(echo "$release_tag" | cut -d. -f2)
-          PATCH=$(echo "$release_tag" | cut -d. -f3)
-          
-          # Create the release with the new tag and generate release notes based on the commits since the last release
+          parse_semver "${release_tag}"
           gh release create "${release_tag}" \
             --title "${release_tag}" \
             --generate-notes
-          
-          # Merge main into the <major>.<minor> branch to update the release branch with the latest changes from main
-          release_branch="${MAJOR}.${MINOR}"
-          git checkout -B "${release_branch}" origin/"${release_branch}" || git checkout -b "${release_branch}"
-          git merge main --no-edit
-          git push origin "${release_branch}"
-          
-          # Merge main into the <major> branch to update the release branch with the latest changes from main
-          release_branch="${MAJOR}"
-          git checkout -B "${release_branch}" origin/"${release_branch}" || git checkout -b "${release_branch}"
-          git merge main --no-edit
-          git push origin "${release_branch}"
+          update_release_branches "${MAJOR}" "${MINOR}"

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -39,63 +39,10 @@ jobs:
         id: bump
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          # Find the latest semver release tag
-          LAST_TAG=$(gh release list --repo "${{ github.repository }}" --json tagName \
-            --jq '[.[] | select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first | .tagName // empty')
-
-          if [[ -z "$LAST_TAG" ]]; then
-            echo "No previous release found, starting at 1.0.0"
-            MAJOR=1; MINOR=0; PATCH=0
-            NEW_TAG="1.0.0"
-            echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          MAJOR=$(echo "$LAST_TAG" | cut -d. -f1)
-          MINOR=$(echo "$LAST_TAG" | cut -d. -f2)
-          PATCH=$(echo "$LAST_TAG" | cut -d. -f3)
-
-          # Collect all commit messages since the last tag
-          COMMITS=$(git log "${LAST_TAG}..HEAD" --format="%s %b")
-
-          # Extract nvidia_drivers and os_versions lists at last tag and HEAD
-          NVIDIA_BEFORE=$(git show "${LAST_TAG}:versions.yaml" 2>/dev/null | \
-            awk '/^nvidia_drivers:/{found=1; next} found && /^[^ -]/{exit} found{print}')
-          NVIDIA_AFTER=$(git show HEAD:versions.yaml | \
-            awk '/^nvidia_drivers:/{found=1; next} found && /^[^ -]/{exit} found{print}')
-
-          OS_BEFORE=$(git show "${LAST_TAG}:versions.yaml" 2>/dev/null | \
-            awk '/^os_versions:/{found=1; next} found && /^[^ -]/{exit} found{print}')
-          OS_AFTER=$(git show HEAD:versions.yaml | \
-            awk '/^os_versions:/{found=1; next} found && /^[^ -]/{exit} found{print}')
-
-          NVIDIA_ADDED=$(diff <(echo "$NVIDIA_BEFORE") <(echo "$NVIDIA_AFTER") | grep -c '^>' || true)
-          OS_ADDED=$(diff <(echo "$OS_BEFORE") <(echo "$OS_AFTER") | grep -c '^>' || true)
-
-          # Detect changes outside of os_versions in versions.yaml
-          VERSIONS_YAML_BEFORE_NO_OS=$(git show "${LAST_TAG}:versions.yaml" 2>/dev/null | \
-             awk '/^os_versions:/{skip=1; next} skip && !/^-/{skip=0} !skip')
-          VERSIONS_YAML_AFTER_NO_OS=$(git show HEAD:versions.yaml | \
-             awk '/^os_versions:/{skip=1; next} skip && !/^-/{skip=0} !skip')
-          VERSIONS_YAML_OTHER_CHANGES=$(diff \
-            <(echo "$VERSIONS_YAML_BEFORE_NO_OS") \
-            <(echo "$VERSIONS_YAML_AFTER_NO_OS") \
-            | grep -c '^>' || true)
-
-          # Count any changed files other than versions.yaml
-          OTHER_FILES_CHANGED=$(git diff --name-only "${LAST_TAG}..HEAD" | grep -cv -e '^versions\.yaml$' -e '^.github\/' -e '^.ci\/' -e '^cdup\/' -e '^docs\/' -e '^history\.yaml$' || true)
-
-          if [[ "$NVIDIA_ADDED" -gt 0 ]] || [[ "$OTHER_FILES_CHANGED" -gt 0 ]] || [[ "$VERSIONS_YAML_OTHER_CHANGES" -gt 0 ]]; then
-            echo "NVIDIA_ADDED: ${NVIDIA_ADDED}, OTHER_FILES_CHANGED: ${OTHER_FILES_CHANGED}, VERSIONS_YAML_OTHER_CHANGES: ${VERSIONS_YAML_OTHER_CHANGES}"
-            MINOR=$((MINOR + 1)); PATCH=0
-          else
-            PATCH=$((PATCH + 1))
-          fi
-
-          NEW_TAG="${MAJOR}.${MINOR}.${PATCH}"
-          echo "Last tag: ${LAST_TAG} → New tag: ${NEW_TAG}"
-          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
+          source .ci/semver.sh
+          bump_semver
 
   update-files:
     needs: determine-version
@@ -177,26 +124,17 @@ jobs:
       - name: Commit and create PR for updated files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.determine-version.outputs.new_tag }}
         run: |
-          TAG="${{ needs.determine-version.outputs.new_tag }}"
+          source .ci/git_ops.sh
           BRANCH="release-update/${TAG}"
-          
-          git config user.name "Garden Linux Builder"
-          git config user.email "gardenlinux@users.noreply.github.com"
-          
-          # Check if there are changes to commit
-          git add helm/gpu-operator-values.yaml helm/gpu-operator-values-runtime.yaml helm/gpu-operator-gvisor-values.yaml README*.md release-version.yaml
-          if git diff --cached --quiet --exit-code; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          
-          # Create a new branch and commit changes
-          git checkout -b "${BRANCH}"
-          git commit -m "Update release references for ${TAG}"
-          git push -f origin "${BRANCH}"
-          
-          PR_LINK=$(gh pr create --base main --head ${BRANCH} --title "Update release references for ${TAG}" --body "Automated PR to update release references for version ${TAG}. Merge PR to create GitHub release.")
+          configure_git_identity "Garden Linux Builder" "gardenlinux@users.noreply.github.com"
+          commit_and_push_branch "${BRANCH}" \
+            helm/gpu-operator-values.yaml helm/gpu-operator-values-runtime.yaml \
+            helm/gpu-operator-gvisor-values.yaml README*.md release-version.yaml
+          create_pr "${BRANCH}" main \
+            "Update release references for ${TAG}" \
+            "Automated PR to update release references for version ${TAG}. Merge PR to create GitHub release."
 
   build-image:
     needs: [determine-version, update-files]

--- a/.github/workflows/test_installer.yml
+++ b/.github/workflows/test_installer.yml
@@ -76,30 +76,10 @@ jobs:
         id: helm-test
         continue-on-error: true
         run: |
+          source .ci/helm_test.sh
           helm test test-release -n gpu-operator --logs 2>&1 | tee test-output.log
-          
-          # Store the helm test exit code
-          HELM_EXIT_CODE=${PIPESTATUS[0]}
-    
-          # Check if the output contains failure indicators
-          if grep -q "FAILED" test-output.log || grep -q "Error" test-output.log; then
-            echo "Test output indicates failure"
-            exit 1
-          fi
-    
-          if [ $HELM_EXIT_CODE -ne 0 ]; then
-            echo "Helm test command failed with exit code: $HELM_EXIT_CODE"
-            exit 1
-          fi
-    
-          TEST_PODS=$(kubectl get pods -n gpu-operator -l "app.kubernetes.io/instance=test-release,test=true" -o jsonpath='{.items[*].metadata.name}')
-          for pod in $TEST_PODS; do
-            POD_STATUS=$(kubectl get pod $pod -n gpu-operator -o jsonpath='{.status.phase}')
-            if [ "$POD_STATUS" != "Succeeded" ]; then
-              echo "Test pod $pod failed with status: $POD_STATUS"
-              exit 1
-            fi
-          done
+          evaluate_helm_test_output test-output.log "${PIPESTATUS[0]}"
+          check_pod_statuses gpu-operator "app.kubernetes.io/instance=test-release,test=true"
 
       - name: Debug on failure
         env:

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -35,13 +35,11 @@ jobs:
       - name: Add versions commit to release branch
         if: ${{ steps.update-version.outputs.has_update == 'true' }}
         run: |
+          source .ci/git_ops.sh
+          configure_git_identity "Garden Linux Builder" "gardenlinux@users.noreply.github.com"
           git checkout -b update-version
-          git add versions.yaml history.yaml
-          git config --global user.name "Garden Linux Builder"
-          git config --global user.email "gardenlinux@users.noreply.github.com"
-          git commit -am 'Update versions'
-          git push --set-upstream origin update-version
-          UPDATE_PR_LINK=$(gh pr create --base main --head update-version --title 'Update versions' --body "automated update")
+          commit_and_push_branch "update-version" versions.yaml history.yaml
+          create_pr "update-version" main "Update versions" "automated update"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Move embedded bash from workflow YAML files into named functions in `.ci/{semver,git_ops,image_folder,matrix_outputs,helm_test,release_branches}.sh`, and add **bats** unit tests in `.ci/test/`. Workflows now source and call the extracted functions. 54 tests pass (10 pre-existing + 44 new).
