### PR TITLE
Docs: Fix typo in index page

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -23,7 +23,7 @@ version updates are applied automatically via CI; major driver version bumps are
 
 ## Runtime Driver compilation
 
-This project also supprts compilation of kernel during runtime. With this feature, the operator automatically 
+This project also supports compilation of kernel during runtime. With this feature, the operator automatically 
 detects the host’s kernel version and builds the required driver modules using the host’s kernel headers.
 To enable runtime driver compilation, apply the Helm values provided in helm/gpu-operator-values-runtime.yaml.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a small typo on the index page to make the docs CI green.

**Which issue(s) this PR fixes**:
Fixes #-