### PR TITLE
Fix: exclude GL 2150.8.0+ + 570.x from build matrix

### DIFF
--- a/.ci/generate_matrix.py
+++ b/.ci/generate_matrix.py
@@ -7,6 +7,25 @@ import sys
 with open("versions.yaml") as f:
     data = yaml.safe_load(f)
 
+exclusions = data.get("excluded_combinations", [])
+
+
+def _ver_tuple(v):
+    return tuple(int(x) for x in str(v).split("."))
+
+
+def is_excluded(os_version, driver_version):
+    for rule in exclusions:
+        os_min = rule.get("os_version_min")
+        drv_pfx = rule.get("driver_version_prefix", "")
+        if os_min and _ver_tuple(os_version) < _ver_tuple(os_min):
+            continue
+        if drv_pfx and not str(driver_version).startswith(drv_pfx):
+            continue
+        return True
+    return False
+
+
 # build_matrix: one entry per (os_version, arch, kernel_flavour, driver).
 # Each image embeds both open and proprietary tarballs; kernel_type is no longer
 # a separate matrix dimension.
@@ -23,6 +42,7 @@ build_matrix = [
         data["kernel_flavour"],
         data["nvidia_drivers"],
     )
+    if not is_excluded(os_version, driver)
 ]
 
 # manifest_matrix: one entry per (os_version, kernel_flavour, driver) — no arch, no kernel_type.
@@ -38,6 +58,7 @@ manifest_matrix = [
         data["kernel_flavour"],
         data["nvidia_drivers"],
     )
+    if not is_excluded(os_version, driver)
 ]
 
 # gvisor_build_matrix: same dimensions as build_matrix but uses pinned driver
@@ -65,6 +86,7 @@ gvisor_build_matrix = [
         data["kernel_flavour"],
         data["nvidia_drivers"],
     )
+    if not is_excluded(os_version, driver)
 ]
 
 gvisor_manifest_matrix = [
@@ -79,6 +101,7 @@ gvisor_manifest_matrix = [
         data["kernel_flavour"],
         data["nvidia_drivers"],
     )
+    if not is_excluded(os_version, driver)
 ]
 
 print(

--- a/versions.yaml
+++ b/versions.yaml
@@ -38,3 +38,7 @@ gvisor_driver_pins:
   590.48.01: 590.48.01
   570.211.01: 570.195.03
   580.173.02: 580.173.02
+excluded_combinations:
+  - os_version_min: "2150.8.0"
+    driver_version_prefix: "570"
+    reason: "GL 2150.8+ ships kernel 6.18.41+ with changed pci_resize_resource signature; 570.x is incompatible (issue #344)"


### PR DESCRIPTION
## Summary

- GL 2150.8 ships kernel 6.18.41 which changed the `pci_resize_resource` signature from 3 to 4 arguments; NVIDIA 570.x fails to compile against it
- Adds an `excluded_combinations` block to `versions.yaml` with an `os_version_min` rule so all current and future 2150.8+ versions are automatically excluded from 570.x builds
- Adds an `is_excluded()` helper in `generate_matrix.py` that filters all four matrices (build, manifest, gvisor_build, gvisor_manifest)

Fixes #344.

## Test plan

- [x] Run `python3 .ci/generate_matrix.py` and confirm no `2150.8.0+` × `570.x` entries appear in any matrix
- [x] Confirm `2150.0.0–2150.7.0` + `570.x` entries are still present
- [x] Confirm `2150.8.0` + `580.x`/`590.x` entries are still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)