### PR TITLE
fix(PATH dropin): move containerd PATH drop-in before fabricmanager

### DIFF
--- a/nvidia-driver
+++ b/nvidia-driver
@@ -1,4 +1,4 @@
 #!/bin/bash
 /opt/nvidia-installer/load_install_gpu_driver.sh
-/opt/nvidia-installer/install_fabricmanager.sh
 /opt/nvidia-installer/install_containerd_path_dropin.sh
+/opt/nvidia-installer/install_fabricmanager.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
install_fabricmanager.sh ends with `sleep infinity` to keep the driver pod alive, which means install_containerd_path_dropin.sh (appended after it in the entrypoint) is never reached.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
