### PR TITLE
fix(ci): make git_ops idempotent for re-runs

### DIFF
--- a/.ci/git_ops.sh
+++ b/.ci/git_ops.sh
@@ -26,17 +26,22 @@ commit_and_push_branch() {
         echo "No changes to commit"
         return 0
     fi
-    git checkout -b "$branch"
+    git checkout -B "$branch"
     git commit -m "Update release references for $branch"
     git push -f origin "$branch"
 }
 
 # create_pr BRANCH BASE TITLE BODY
-# Creates a GitHub PR from BRANCH into BASE.
+# Creates a GitHub PR from BRANCH into BASE, or updates the existing one.
 create_pr() {
     local branch="$1"
     local base="$2"
     local title="$3"
     local body="$4"
-    gh pr create --base "$base" --head "$branch" --title "$title" --body "$body"
+    if gh pr view "$branch" --json state -q '.state' 2>/dev/null | grep -q "OPEN"; then
+        echo "PR from $branch already exists, updating"
+        gh pr edit "$branch" --title "$title" --body "$body"
+    else
+        gh pr create --base "$base" --head "$branch" --title "$title" --body "$body"
+    fi
 }

--- a/.ci/test/test_git_ops.bats
+++ b/.ci/test/test_git_ops.bats
@@ -73,7 +73,7 @@ setup() {
         case "$*" in
             "add file-a.yaml file-b.yaml") ;;
             "diff --cached --quiet --exit-code") return 1 ;;
-            "checkout -b release-update/1.2.0") ;;
+            "checkout -B release-update/1.2.0") ;;
             "commit -m Update release references for release-update/1.2.0") ;;
             "push -f origin release-update/1.2.0") PUSH_CALLED=true ;;
             *) ;;

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           source .ci/git_ops.sh
           configure_git_identity "Garden Linux Builder" "gardenlinux@users.noreply.github.com"
-          git checkout -b update-version
           commit_and_push_branch "update-version" versions.yaml history.yaml
           create_pr "update-version" main "Update versions" "automated update"
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove duplicate `git checkout -b` in update_version workflow that caused 'branch already exists' failures.
Use checkout `-B` to handle pre-existing branches, and make create_pr update existing PRs instead of failing.

**Fixes**:
update-version workflow https://github.com/gardenlinux/gardenlinux-nvidia-installer/actions/runs/31980894746/job/95247332142#step:6:13

and likely #350 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
