### PR TITLE
fix: patch iommu for nvidia GPU ports

### DIFF
--- a/resources/load_install_gpu_driver.sh
+++ b/resources/load_install_gpu_driver.sh
@@ -184,9 +184,6 @@ _has_older_kernel() {
 # -D: include domain in BDF; -d 10de:: NVIDIA vendor; -n: numeric IDs
 # awk filters to PCI class 0300 (VGA) and 0302 (3D controller), excluding
 # other NVIDIA functions like audio (0403) that share the same vendor ID.
-# Uses nsenter to read the host PCI bus rather than the container's view.
-_lspci_nvidia_gpus() {
-    nsenter -t 1 -m -u -n -i -- lspci -D -d 10de: -n 2>/dev/null | awk '/030[02]/'
 # The container is privileged with host sysfs mounted, so lspci sees host PCI devices directly.
 _lspci_nvidia_gpus() {
     lspci -D -d 10de: -n 2>/dev/null | awk '/030[02]/'

--- a/resources/load_install_gpu_driver.sh
+++ b/resources/load_install_gpu_driver.sh
@@ -187,6 +187,9 @@ _has_older_kernel() {
 # Uses nsenter to read the host PCI bus rather than the container's view.
 _lspci_nvidia_gpus() {
     nsenter -t 1 -m -u -n -i -- lspci -D -d 10de: -n 2>/dev/null | awk '/030[02]/'
+# The container is privileged with host sysfs mounted, so lspci sees host PCI devices directly.
+_lspci_nvidia_gpus() {
+    lspci -D -d 10de: -n 2>/dev/null | awk '/030[02]/'
 }
 
 # Returns 0 (true) if any NVIDIA GPU on the host has a PCI device ID below 0x1E00,

--- a/resources/load_install_gpu_driver.sh
+++ b/resources/load_install_gpu_driver.sh
@@ -43,6 +43,7 @@ main() {
     # ------------------------------------------------------------------------------
     resolve_kernel_module_type
     locate_driver_tarball
+    set_nvidia_iommu_passthrough
 
     # Stage new contents into a temporary directory
     rm -rf /run/nvidia/.staging-driver || true
@@ -179,23 +180,26 @@ _has_older_kernel() {
 }
 
 
+# Emits one line per NVIDIA GPU on the host as: "<BDF> <class> <vendor>:<devid>"
+# -D: include domain in BDF; -d 10de:: NVIDIA vendor; -n: numeric IDs
+# awk filters to PCI class 0300 (VGA) and 0302 (3D controller), excluding
+# other NVIDIA functions like audio (0403) that share the same vendor ID.
+# Uses nsenter to read the host PCI bus rather than the container's view.
+_lspci_nvidia_gpus() {
+    nsenter -t 1 -m -u -n -i -- lspci -D -d 10de: -n 2>/dev/null | awk '/030[02]/'
+}
+
 # Returns 0 (true) if any NVIDIA GPU on the host has a PCI device ID below 0x1E00,
 # which indicates a pre-Turing architecture (Maxwell, Pascal, or Volta).
 # Turing (TU102+) and all newer architectures start at device ID 0x1E00.
-# lspci is called via nsenter so it reads the host PCI bus, not the container's view.
 _has_pre_turing_gpu() {
     local dev_id
-    # List NVIDIA GPUs (vendor 10de, PCI class 0300 VGA or 0302 3D controller).
-    # -d 10de: selects NVIDIA vendor; -n prints numeric IDs; awk extracts the device ID field.
     while IFS= read -r dev_id; do
         # dev_id is a 4-digit hex string, e.g. "1db1". Compare numerically against 0x1E00.
         if [ $(( 16#${dev_id} )) -lt $(( 16#1E00 )) ]; then
             return 0
         fi
-    done < <(nsenter -t 1 -m -u -n -i -- \
-        lspci -d 10de: -n 2>/dev/null \
-        | awk '{ print $3 }' \
-        | cut -d: -f2)
+    done < <(_lspci_nvidia_gpus | awk '{ print $3 }' | cut -d: -f2)
     return 1
 }
 
@@ -215,6 +219,27 @@ locate_driver_tarball() {
     export DRIVER_TARBALL_PATH
 }
 
+
+set_nvidia_iommu_passthrough() {
+    # Switch IOMMU group type to 'identity' (passthrough) for NVIDIA GPU devices before
+    # modules are loaded. Without this, GPUs in strict 'DMA' IOMMU groups can trigger
+    # IO_PAGE_FAULTs during modprobe and fail to get /dev/nvidia* nodes.
+    # https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-kernel-iommu_groups
+    local bdf type_path
+    while IFS= read -r bdf; do
+        type_path="/sys/bus/pci/devices/${bdf}/iommu_group/type"
+        [ -f "${type_path}" ] || continue
+        local current
+        current=$(cat "${type_path}")
+        if [ "${current}" != "identity" ]; then
+            if echo identity > "${type_path}" 2>/dev/null; then
+                echo "[INFO] IOMMU group for ${bdf}: ${current} -> identity"
+            else
+                echo "[WARN] Could not set IOMMU passthrough for ${bdf} (current: ${current})"
+            fi
+        fi
+    done < <(_lspci_nvidia_gpus | awk '{print $1}')
+}
 
 install() {
     local DRIVER_NAME=$1


### PR DESCRIPTION
**What this PR does / why we need it**:

On some multi-socket bare-metal nodes, only gpus on the first cpu socket were visible after driver installation. The root cause is that gpus on the second socket land in a stricter iommu mode (dma) that causes `nvidia-modprobe` to fail creating their device nodes.

The fix sets iommu passthrough mode for all nvidia gpus before the driver loads. BDFs are discovered dynamically so no hardcoded addresses are needed. On nodes that are already in passthrough mode this is a no-op.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix missing GPUs on multi-socket nodes where strict iommu mode prevented the driver from enumerating all GPUs.
```