### PR TITLE
fix(ci): fail update_versions on tag fetch errors

### DIFF
--- a/.ci/update_versions.py
+++ b/.ci/update_versions.py
@@ -148,8 +148,7 @@ def get_latest_gardenlinux_tags(data):
     response = requests.get(url)
 
     if response.status_code != 200:
-        print("Failed to fetch tags:", response.status_code, file=__import__('sys').stderr)
-        return False
+        raise RuntimeError(f"Failed to fetch tags: {response.status_code}")
 
     tags = [tag['name'] for tag in response.json()]
     new_os_versions = [tag for tag in tags if re.fullmatch(r'\d+\.\d+(\.\d+)?', tag)]


### PR DESCRIPTION
**What this PR does / why we need it**:
check-versions should fail in case the API returns non 200 code

A simple `return false` is not enough for https://github.com/gardenlinux/gardenlinux-nvidia-installer/blob/7dd97a72be5e54cd8ba2e531c32c3a56e2e07fa0/.github/workflows/update_version.yml#L20 to fail 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
