### PR TITLE
fix(ci): use pull_request_target for release-process workflow

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -1,7 +1,13 @@
 name: Release process
 
 on:
-  pull_request:
+  # pull_request_target runs in the context of the BASE repository, granting
+  # write access even when the merged PR originated from a fork.
+  #
+  # Security: safe because (1) types: [closed] + merged==true means only
+  # maintainer-approved merges trigger execution, (2) checkout uses the base
+  # branch (main), never the PR head — no untrusted fork code is executed.
+  pull_request_target:
     branches: [main]
     types: [closed]
     paths-ignore:
@@ -16,6 +22,7 @@ on:
     # Don't trigger on documentation changes
       - 'docs/**'
       - '*.md'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -25,7 +32,8 @@ permissions:
 
 jobs:
   determine-version:
-    if: github.event.pull_request.merged == true # Only run if the PR was merged - needed to avoid creating a release for every PR that is closed without merging
+    # Only run if manually dispatched or if the PR was actually merged (not just closed without merging)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.bump.outputs.new_tag }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The release-process workflow incorrectly ran on the fork itself when a
fork PR was merged, instead of running on the upstream repository. This
caused a permission denied error when trying to push to the upstream.

Switch to `pull_request_target` which always runs in the base repo context.
Add `workflow_dispatch` for manual re-runs. Update the job condition to
support both triggers.

**Which issue(s) this PR fixes**:
This: https://github.com/gardenlinux/gardenlinux-nvidia-installer/actions/runs/32243696613 should not happen. a release-process action running on a fork. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
